### PR TITLE
BigQuery/TransformKeys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-Big Data Types 0.0.6 (Release TBD)
+Big Data Types 0.0.6
 
 - BigQuery: JavaConverters for cross version builds
 - BigQuery: Formats object that allows different keys transformation like CamelCase -> snake_case for fields

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 Big Data Types 0.0.6 (Release TBD)
 
 - BigQuery: JavaConverters for cross version builds
+- BigQuery: Formats object that allows different keys transformation like CamelCase -> snake_case for fields

--- a/README.md
+++ b/README.md
@@ -22,15 +22,32 @@ Versions for Scala 2.12 and 2.13 are available in Maven
 ### Create BigQuery Tables
 
 ```scala
+import org.datatools.bigdatatypes.bigquery.BigQueryTable
+import org.datatools.bigdatatypes.formats.TransformKeys.defaultFormats
+
 case class MyTable(field1: Int, field2: String)
 BigQueryTable.createTable[MyTable]("dataset_name", "table_name")
 ```
 This also works with Structs, Lists and Options.
 See more examples in [Tests](https://github.com/data-tools/big-data-types/blob/main/src/it/scala/org/datatools/bigdatatypes/bigquery/BigQueryTableSpec.scala)
 
+#### Transform field names
+There is a `Format` object that allows us to decide how to transform field names, for example, changing CamelCase for snake case
+```scala
+import org.datatools.bigdatatypes.bigquery.BigQueryTable
+import org.datatools.bigdatatypes.formats.TransformKeys.snakifyFields
+
+case class MyTable(myIntField: Int, myStringField: String)
+BigQueryTable.createTable[MyTable]("dataset_name", "table_name")
+//This table will have my_int_field and my_string_field fields
+```
+
 #### Time Partitioned tables
 Using a `Timestamp` or `Date` field, tables can be partitioned in BigQuery using a [Time Partition Column](https://cloud.google.com/bigquery/docs/creating-column-partitions)
 ```scala
+import org.datatools.bigdatatypes.bigquery.BigQueryTable
+import org.datatools.bigdatatypes.formats.TransformKeys.snakifyFields
+
 case class MyTable(field1: Int, field2: String, myPartitionField: java.sql.Timestamp)
 BigQueryTable.createTable[MyTable]("dataset_name", "table_name", "my_partition_field")
 ```

--- a/src/it/scala/org/datatools/bigdatatypes/bigquery/BigQueryTableSpec.scala
+++ b/src/it/scala/org/datatools/bigdatatypes/bigquery/BigQueryTableSpec.scala
@@ -2,6 +2,7 @@ package org.datatools.bigdatatypes.bigquery
 
 import org.datatools.bigdatatypes.IntegrationSpec
 import org.datatools.bigdatatypes.DummyModels._
+import org.datatools.bigdatatypes.formats.TransformKeys.snakifyFields
 
 import scala.util.Right
 

--- a/src/main/scala/org/datatools/bigdatatypes/bigquery/BigQueryDefinitions.scala
+++ b/src/main/scala/org/datatools/bigdatatypes/bigquery/BigQueryDefinitions.scala
@@ -2,7 +2,7 @@ package org.datatools.bigdatatypes.bigquery
 
 import com.google.cloud.bigquery.{Schema, StandardTableDefinition, TimePartitioning}
 import org.datatools.bigdatatypes.bigquery.JavaConverters.toJava
-import org.datatools.bigdatatypes.formats.{DefaultFormats, Formats}
+import org.datatools.bigdatatypes.formats.Formats
 
 
 private[bigquery] object BigQueryDefinitions {

--- a/src/main/scala/org/datatools/bigdatatypes/bigquery/BigQueryDefinitions.scala
+++ b/src/main/scala/org/datatools/bigdatatypes/bigquery/BigQueryDefinitions.scala
@@ -2,7 +2,6 @@ package org.datatools.bigdatatypes.bigquery
 
 import com.google.cloud.bigquery.{Schema, StandardTableDefinition, TimePartitioning}
 import org.datatools.bigdatatypes.bigquery.JavaConverters.toJava
-import org.datatools.bigdatatypes.formats.Formats
 
 
 private[bigquery] object BigQueryDefinitions {
@@ -14,7 +13,7 @@ private[bigquery] object BigQueryDefinitions {
   /** Generates a Table definition with or without Time Partitioning Column
    * @param partitionColumn name of the column that will be a time partition, if None, no partition will be created
    */
-  def generateTableDefinition[A: BigQueryTypes](partitionColumn: Option[String])(implicit f: Formats): StandardTableDefinition = {
+  def generateTableDefinition[A: BigQueryTypes](partitionColumn: Option[String]): StandardTableDefinition = {
     val builder: StandardTableDefinition.Builder = StandardTableDefinition.newBuilder().setSchema(generateSchema[A])
     addPartitionToBuilder(builder, partitionColumn).build()
   }

--- a/src/main/scala/org/datatools/bigdatatypes/bigquery/BigQueryDefinitions.scala
+++ b/src/main/scala/org/datatools/bigdatatypes/bigquery/BigQueryDefinitions.scala
@@ -2,6 +2,7 @@ package org.datatools.bigdatatypes.bigquery
 
 import com.google.cloud.bigquery.{Schema, StandardTableDefinition, TimePartitioning}
 import org.datatools.bigdatatypes.bigquery.JavaConverters.toJava
+import org.datatools.bigdatatypes.formats.{DefaultFormats, Formats}
 
 
 private[bigquery] object BigQueryDefinitions {
@@ -13,7 +14,7 @@ private[bigquery] object BigQueryDefinitions {
   /** Generates a Table definition with or without Time Partitioning Column
    * @param partitionColumn name of the column that will be a time partition, if None, no partition will be created
    */
-  def generateTableDefinition[A: BigQueryTypes](partitionColumn: Option[String]): StandardTableDefinition = {
+  def generateTableDefinition[A: BigQueryTypes](partitionColumn: Option[String])(implicit f: Formats): StandardTableDefinition = {
     val builder: StandardTableDefinition.Builder = StandardTableDefinition.newBuilder().setSchema(generateSchema[A])
     addPartitionToBuilder(builder, partitionColumn).build()
   }

--- a/src/main/scala/org/datatools/bigdatatypes/bigquery/BigQueryTable.scala
+++ b/src/main/scala/org/datatools/bigdatatypes/bigquery/BigQueryTable.scala
@@ -12,7 +12,7 @@ object BigQueryTable {
 
   /** Create a table without partitions
     */
-  def createTable[A: BigQueryTypes](datasetName: String, tableName: String)(implicit f: Formats): Either[BigQueryError, Table] = createTable[A](datasetName, tableName, None)
+  def createTable[A: BigQueryTypes](datasetName: String, tableName: String): Either[BigQueryError, Table] = createTable[A](datasetName, tableName, None)
   def createTable[A: BigQueryTypes, B: BigQueryTypes](datasetName: String, tableName: String): Either[BigQueryError, Table] = createTable[A, B](datasetName, tableName, None)
   def createTable[A: BigQueryTypes, B: BigQueryTypes, C: BigQueryTypes](datasetName: String, tableName: String): Either[BigQueryError, Table] = createTable[A, B, C](datasetName, tableName, None)
   def createTable[A: BigQueryTypes, B: BigQueryTypes, C: BigQueryTypes, D: BigQueryTypes](datasetName: String, tableName: String): Either[BigQueryError, Table] = createTable[A, B, C, D](datasetName, tableName, None)
@@ -20,7 +20,7 @@ object BigQueryTable {
 
   /** Create partitioned table
     */
-  def createTable[A: BigQueryTypes](datasetName: String, tableName: String, timePartitionColumn: String)(implicit f: Formats): Either[BigQueryError, Table] = createTable[A](datasetName, tableName, Some(timePartitionColumn))
+  def createTable[A: BigQueryTypes](datasetName: String, tableName: String, timePartitionColumn: String): Either[BigQueryError, Table] = createTable[A](datasetName, tableName, Some(timePartitionColumn))
   def createTable[A: BigQueryTypes, B: BigQueryTypes](datasetName: String, tableName: String, timePartitionColumn: String): Either[BigQueryError, Table] = createTable[A, B](datasetName, tableName, Some(timePartitionColumn))
   def createTable[A: BigQueryTypes, B: BigQueryTypes, C: BigQueryTypes](datasetName: String, tableName: String, timePartitionColumn: String): Either[BigQueryError, Table] = createTable[A, B, C](datasetName, tableName, Some(timePartitionColumn))
   def createTable[A: BigQueryTypes, B: BigQueryTypes, C: BigQueryTypes, D: BigQueryTypes](datasetName: String, tableName: String, timePartitionColumn: String): Either[BigQueryError, Table] = createTable[A, B, C, D](datasetName, tableName, Some(timePartitionColumn))
@@ -28,7 +28,7 @@ object BigQueryTable {
 
   /** Create a table in BigQuery
     */
-  private def createTable[A: BigQueryTypes](datasetName: String, tableName: String, timePartitionColumn: Option[String])(implicit f: Formats): Either[BigQueryError, Table] = tryTable(TableId.of(datasetName, tableName), generateTableDefinition[A](timePartitionColumn))
+  private def createTable[A: BigQueryTypes](datasetName: String, tableName: String, timePartitionColumn: Option[String]): Either[BigQueryError, Table] = tryTable(TableId.of(datasetName, tableName), generateTableDefinition[A](timePartitionColumn))
   private def createTable[A: BigQueryTypes, B: BigQueryTypes](datasetName: String, tableName: String, timePartitionColumn: Option[String]): Either[BigQueryError, Table] = tryTable(TableId.of(datasetName, tableName), generateTableDefinition[A, B](timePartitionColumn))
   private def createTable[A: BigQueryTypes, B: BigQueryTypes, C: BigQueryTypes](datasetName: String, tableName: String, timePartitionColumn: Option[String]): Either[BigQueryError, Table] = tryTable(TableId.of(datasetName, tableName), generateTableDefinition[A, B, C](timePartitionColumn))
   private def createTable[A: BigQueryTypes, B: BigQueryTypes, C: BigQueryTypes, D: BigQueryTypes](datasetName: String, tableName: String, timePartitionColumn: Option[String]): Either[BigQueryError, Table] = tryTable(TableId.of(datasetName, tableName), generateTableDefinition[A, B, C, D](timePartitionColumn))

--- a/src/main/scala/org/datatools/bigdatatypes/bigquery/BigQueryTable.scala
+++ b/src/main/scala/org/datatools/bigdatatypes/bigquery/BigQueryTable.scala
@@ -2,6 +2,7 @@ package org.datatools.bigdatatypes.bigquery
 
 import com.google.cloud.bigquery.{BigQuery, BigQueryError, BigQueryException, BigQueryOptions, Table, TableDefinition, TableId, TableInfo}
 import org.datatools.bigdatatypes.bigquery.BigQueryDefinitions.generateTableDefinition
+import org.datatools.bigdatatypes.formats.Formats
 
 import scala.util.{Failure, Try}
 
@@ -11,7 +12,7 @@ object BigQueryTable {
 
   /** Create a table without partitions
     */
-  def createTable[A: BigQueryTypes](datasetName: String, tableName: String): Either[BigQueryError, Table] = createTable[A](datasetName, tableName, None)
+  def createTable[A: BigQueryTypes](datasetName: String, tableName: String)(implicit f: Formats): Either[BigQueryError, Table] = createTable[A](datasetName, tableName, None)
   def createTable[A: BigQueryTypes, B: BigQueryTypes](datasetName: String, tableName: String): Either[BigQueryError, Table] = createTable[A, B](datasetName, tableName, None)
   def createTable[A: BigQueryTypes, B: BigQueryTypes, C: BigQueryTypes](datasetName: String, tableName: String): Either[BigQueryError, Table] = createTable[A, B, C](datasetName, tableName, None)
   def createTable[A: BigQueryTypes, B: BigQueryTypes, C: BigQueryTypes, D: BigQueryTypes](datasetName: String, tableName: String): Either[BigQueryError, Table] = createTable[A, B, C, D](datasetName, tableName, None)
@@ -19,7 +20,7 @@ object BigQueryTable {
 
   /** Create partitioned table
     */
-  def createTable[A: BigQueryTypes](datasetName: String, tableName: String, timePartitionColumn: String): Either[BigQueryError, Table] = createTable[A](datasetName, tableName, Some(timePartitionColumn))
+  def createTable[A: BigQueryTypes](datasetName: String, tableName: String, timePartitionColumn: String)(implicit f: Formats): Either[BigQueryError, Table] = createTable[A](datasetName, tableName, Some(timePartitionColumn))
   def createTable[A: BigQueryTypes, B: BigQueryTypes](datasetName: String, tableName: String, timePartitionColumn: String): Either[BigQueryError, Table] = createTable[A, B](datasetName, tableName, Some(timePartitionColumn))
   def createTable[A: BigQueryTypes, B: BigQueryTypes, C: BigQueryTypes](datasetName: String, tableName: String, timePartitionColumn: String): Either[BigQueryError, Table] = createTable[A, B, C](datasetName, tableName, Some(timePartitionColumn))
   def createTable[A: BigQueryTypes, B: BigQueryTypes, C: BigQueryTypes, D: BigQueryTypes](datasetName: String, tableName: String, timePartitionColumn: String): Either[BigQueryError, Table] = createTable[A, B, C, D](datasetName, tableName, Some(timePartitionColumn))
@@ -27,7 +28,7 @@ object BigQueryTable {
 
   /** Create a table in BigQuery
     */
-  private def createTable[A: BigQueryTypes](datasetName: String, tableName: String, timePartitionColumn: Option[String]): Either[BigQueryError, Table] = tryTable(TableId.of(datasetName, tableName), generateTableDefinition[A](timePartitionColumn))
+  private def createTable[A: BigQueryTypes](datasetName: String, tableName: String, timePartitionColumn: Option[String])(implicit f: Formats): Either[BigQueryError, Table] = tryTable(TableId.of(datasetName, tableName), generateTableDefinition[A](timePartitionColumn))
   private def createTable[A: BigQueryTypes, B: BigQueryTypes](datasetName: String, tableName: String, timePartitionColumn: Option[String]): Either[BigQueryError, Table] = tryTable(TableId.of(datasetName, tableName), generateTableDefinition[A, B](timePartitionColumn))
   private def createTable[A: BigQueryTypes, B: BigQueryTypes, C: BigQueryTypes](datasetName: String, tableName: String, timePartitionColumn: Option[String]): Either[BigQueryError, Table] = tryTable(TableId.of(datasetName, tableName), generateTableDefinition[A, B, C](timePartitionColumn))
   private def createTable[A: BigQueryTypes, B: BigQueryTypes, C: BigQueryTypes, D: BigQueryTypes](datasetName: String, tableName: String, timePartitionColumn: Option[String]): Either[BigQueryError, Table] = tryTable(TableId.of(datasetName, tableName), generateTableDefinition[A, B, C, D](timePartitionColumn))

--- a/src/main/scala/org/datatools/bigdatatypes/bigquery/BigQueryTable.scala
+++ b/src/main/scala/org/datatools/bigdatatypes/bigquery/BigQueryTable.scala
@@ -2,8 +2,6 @@ package org.datatools.bigdatatypes.bigquery
 
 import com.google.cloud.bigquery.{BigQuery, BigQueryError, BigQueryException, BigQueryOptions, Table, TableDefinition, TableId, TableInfo}
 import org.datatools.bigdatatypes.bigquery.BigQueryDefinitions.generateTableDefinition
-import org.datatools.bigdatatypes.formats.Formats
-
 import scala.util.{Failure, Try}
 
 object BigQueryTable {

--- a/src/main/scala/org/datatools/bigdatatypes/formats/DefaultTransformKeys.scala
+++ b/src/main/scala/org/datatools/bigdatatypes/formats/DefaultTransformKeys.scala
@@ -4,15 +4,16 @@ trait Formats extends Serializable {
   def transformKeys(s: String): String
 }
 
+/** Default Formats transforms nothing
+  */
 trait DefaultFormats extends Formats {
 
   override def transformKeys(key: String): String = key
 }
 object DefaultFormats extends DefaultFormats
 
-/**
- * Converts CamelCase field names to snake_case
- */
+/** Converts CamelCase field names to snake_case
+  */
 trait SnakifyFormats extends Formats {
 
   override def transformKeys(key: String): String = key
@@ -23,6 +24,8 @@ trait SnakifyFormats extends Formats {
 
 object SnakifyFormats extends SnakifyFormats
 
+/** Formats as implicit vals, it allows to import them instead of declaring a new implicit val
+  */
 object TransformKeys {
   implicit val defaultFormats: Formats = DefaultFormats
   implicit val snakifyFields: Formats = SnakifyFormats

--- a/src/main/scala/org/datatools/bigdatatypes/formats/DefaultTransformKeys.scala
+++ b/src/main/scala/org/datatools/bigdatatypes/formats/DefaultTransformKeys.scala
@@ -13,7 +13,7 @@ object DefaultFormats extends DefaultFormats
 /**
  * Converts CamelCase field names to snake_case
  */
-trait SnakifyFormats extends DefaultFormats {
+trait SnakifyFormats extends Formats {
 
   override def transformKeys(key: String): String = key
     .replaceAll("([A-Z]+)([A-Z][a-z])", "$1_$2")
@@ -22,3 +22,8 @@ trait SnakifyFormats extends DefaultFormats {
 }
 
 object SnakifyFormats extends SnakifyFormats
+
+object TransformKeys {
+  implicit val defaultFormats: Formats = DefaultFormats
+  implicit val snakifyFields: Formats = SnakifyFormats
+}

--- a/src/main/scala/org/datatools/bigdatatypes/formats/DefaultTransformKeys.scala
+++ b/src/main/scala/org/datatools/bigdatatypes/formats/DefaultTransformKeys.scala
@@ -1,0 +1,24 @@
+package org.datatools.bigdatatypes.formats
+
+trait Formats extends Serializable {
+  def transformKeys(s: String): String
+}
+
+trait DefaultFormats extends Formats {
+
+  override def transformKeys(key: String): String = key
+}
+object DefaultFormats extends DefaultFormats
+
+/**
+ * Converts CamelCase field names to snake_case
+ */
+trait SnakifyFormats extends DefaultFormats {
+
+  override def transformKeys(key: String): String = key
+    .replaceAll("([A-Z]+)([A-Z][a-z])", "$1_$2")
+    .replaceAll("([a-z\\d])([A-Z])", "$1_$2")
+    .toLowerCase
+}
+
+object SnakifyFormats extends SnakifyFormats

--- a/src/test/scala/org/datatools/bigdatatypes/bigquery/BigQueryDefinitionsSpec.scala
+++ b/src/test/scala/org/datatools/bigdatatypes/bigquery/BigQueryDefinitionsSpec.scala
@@ -3,6 +3,9 @@ package org.datatools.bigdatatypes.bigquery
 import com.google.cloud.bigquery.{FieldList, StandardTableDefinition}
 import org.datatools.bigdatatypes.UnitSpec
 import org.datatools.bigdatatypes.bigquery.BigQueryFields.getFieldNames
+import org.datatools.bigdatatypes.conversions.SqlStructTypeConversion
+import org.datatools.bigdatatypes.formats.{DefaultFormats, Formats, SnakifyFormats}
+import org.datatools.bigdatatypes.types.basic.SqlStruct
 
 
 class BigQueryDefinitionsSpec extends UnitSpec {
@@ -10,12 +13,28 @@ class BigQueryDefinitionsSpec extends UnitSpec {
   behavior of "BigQueryDefinitionsSpec"
 
   case class Simple(id: String, number: Int)
+  case class CamelCase(myId: String, myNumber: Int)
 
 
   "Simple definition without partition" should "generate a Table Definition" in {
+    implicit val f: Formats = DefaultFormats
     val table: StandardTableDefinition = BigQueryDefinitions.generateTableDefinition[Simple](None)
     val names: List[String] = getFieldNames(table.getSchema.getFields)
     names should contain.only("id", "number")
+  }
+
+  "Keys" should "remain equal with identity" in {
+    implicit val f: Formats = DefaultFormats
+    val table: StandardTableDefinition = BigQueryDefinitions.generateTableDefinition[CamelCase](None)
+    val names: List[String] = getFieldNames(table.getSchema.getFields)
+    names should contain.only("myId", "myNumber")
+  }
+
+  "Keys" should "be snakified" in {
+    implicit val f: Formats = SnakifyFormats
+    val table: StandardTableDefinition = BigQueryDefinitions.generateTableDefinition[CamelCase](None)
+    val names: List[String] = getFieldNames(table.getSchema.getFields)
+    names should contain.only("my_id", "my_number")
   }
 
   it should "generateTimePartitionColumn" in {}

--- a/src/test/scala/org/datatools/bigdatatypes/bigquery/BigQueryDefinitionsSpec.scala
+++ b/src/test/scala/org/datatools/bigdatatypes/bigquery/BigQueryDefinitionsSpec.scala
@@ -3,9 +3,6 @@ package org.datatools.bigdatatypes.bigquery
 import com.google.cloud.bigquery.{FieldList, StandardTableDefinition}
 import org.datatools.bigdatatypes.UnitSpec
 import org.datatools.bigdatatypes.bigquery.BigQueryFields.getFieldNames
-import org.datatools.bigdatatypes.conversions.SqlStructTypeConversion
-import org.datatools.bigdatatypes.formats.{DefaultFormats, Formats, SnakifyFormats}
-import org.datatools.bigdatatypes.types.basic.SqlStruct
 
 
 class BigQueryDefinitionsSpec extends UnitSpec {
@@ -17,21 +14,22 @@ class BigQueryDefinitionsSpec extends UnitSpec {
 
 
   "Simple definition without partition" should "generate a Table Definition" in {
-    implicit val f: Formats = DefaultFormats
+    //implicit val f: Formats = DefaultFormats
+    import org.datatools.bigdatatypes.formats.TransformKeys.defaultFormats
     val table: StandardTableDefinition = BigQueryDefinitions.generateTableDefinition[Simple](None)
     val names: List[String] = getFieldNames(table.getSchema.getFields)
     names should contain.only("id", "number")
   }
 
   "Keys" should "remain equal with identity" in {
-    implicit val f: Formats = DefaultFormats
+    import org.datatools.bigdatatypes.formats.TransformKeys.defaultFormats
     val table: StandardTableDefinition = BigQueryDefinitions.generateTableDefinition[CamelCase](None)
     val names: List[String] = getFieldNames(table.getSchema.getFields)
     names should contain.only("myId", "myNumber")
   }
 
   "Keys" should "be snakified" in {
-    implicit val f: Formats = SnakifyFormats
+    import org.datatools.bigdatatypes.formats.TransformKeys.snakifyFields
     val table: StandardTableDefinition = BigQueryDefinitions.generateTableDefinition[CamelCase](None)
     val names: List[String] = getFieldNames(table.getSchema.getFields)
     names should contain.only("my_id", "my_number")


### PR DESCRIPTION
- BigQuery: JavaConverters for cross version builds
- BigQuery: Formats object that allows different keys transformation like CamelCase -> snake_case for fields