### PR TITLE
Spark/ReverseConversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### Big Data Types v0.3.0
+
+- Spark: Added reverse conversion (From Spark schemas to generic SqlTypes)
+- Added SqlDouble as a new type in `Core` and `Spark`. (BigQuery does not have Doubles)
+
 ### Big Data Types v0.2.1
 
 - Project split into multiple projects

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 ![CI Tests](https://github.com/data-tools/big-data-types/workflows/ci-tests/badge.svg)
 [![codecov](https://codecov.io/gh/data-tools/big-data-types/branch/main/graph/badge.svg)](https://codecov.io/gh/data-tools/big-data-types)
 ![Maven Central](https://img.shields.io/maven-central/v/io.github.data-tools/big-data-types-core_2.13)
-![Scala 2.12](https://img.shields.io/badge/Scala-2.12-red)
-![Scala_2.13](https://img.shields.io/badge/Scala-2.13-red)
+[![Scala Steward badge](https://img.shields.io/badge/Scala_Steward-helping-blue.svg?style=flat&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAQCAMAAAARSr4IAAAAVFBMVEUAAACHjojlOy5NWlrKzcYRKjGFjIbp293YycuLa3pYY2LSqql4f3pCUFTgSjNodYRmcXUsPD/NTTbjRS+2jomhgnzNc223cGvZS0HaSD0XLjbaSjElhIr+AAAAAXRSTlMAQObYZgAAAHlJREFUCNdNyosOwyAIhWHAQS1Vt7a77/3fcxxdmv0xwmckutAR1nkm4ggbyEcg/wWmlGLDAA3oL50xi6fk5ffZ3E2E3QfZDCcCN2YtbEWZt+Drc6u6rlqv7Uk0LdKqqr5rk2UCRXOk0vmQKGfc94nOJyQjouF9H/wCc9gECEYfONoAAAAASUVORK5CYII=)](https://scala-steward.org)
 
 A library to transform Case Classes into Database schemas
 

--- a/bigquery/src/main/scala/org/datatools/bigdatatypes/bigquery/BigQueryTypes.scala
+++ b/bigquery/src/main/scala/org/datatools/bigdatatypes/bigquery/BigQueryTypes.scala
@@ -52,6 +52,8 @@ object BigQueryTypes {
       Field.newBuilder(name, StandardSQLTypeName.INT64).setMode(sqlModeToBigQueryMode(mode)).build()
     case SqlFloat(mode) =>
       Field.newBuilder(name, StandardSQLTypeName.FLOAT64).setMode(sqlModeToBigQueryMode(mode)).build()
+    case SqlDouble(mode) =>
+      Field.newBuilder(name, StandardSQLTypeName.FLOAT64).setMode(sqlModeToBigQueryMode(mode)).build()
     case SqlDecimal(mode) =>
       Field.newBuilder(name, StandardSQLTypeName.NUMERIC).setMode(sqlModeToBigQueryMode(mode)).build()
     case SqlBool(mode) =>

--- a/build.sbt
+++ b/build.sbt
@@ -48,8 +48,6 @@ lazy val bigqueryDependencies = Seq(
 )
 
 lazy val sparkDependencies = Seq(
-  "com.google.cloud" % "google-cloud-bigquery" % "1.126.6",
-  "io.github.data-tools" % "big-data-types-bigquery_2.12" % "0.2.1",
   "org.apache.spark" %% "spark-core" % "3.1.0" % Provided,
   "org.apache.spark" %% "spark-sql" % "3.1.0" % Provided,
   scalatest % Test

--- a/build.sbt
+++ b/build.sbt
@@ -48,6 +48,8 @@ lazy val bigqueryDependencies = Seq(
 )
 
 lazy val sparkDependencies = Seq(
+  "com.google.cloud" % "google-cloud-bigquery" % "1.126.6",
+  "io.github.data-tools" % "big-data-types-bigquery_2.12" % "0.2.1",
   "org.apache.spark" %% "spark-core" % "3.1.0" % Provided,
   "org.apache.spark" %% "spark-sql" % "3.1.0" % Provided,
   scalatest % Test

--- a/core/src/main/scala/org/datatools/bigdatatypes/conversions/SqlTypeConversion.scala
+++ b/core/src/main/scala/org/datatools/bigdatatypes/conversions/SqlTypeConversion.scala
@@ -39,7 +39,7 @@ object SqlTypeConversion {
   // Basic types
   implicit val intType: SqlTypeConversion[Int] = instance(SqlInt())
   implicit val longType: SqlTypeConversion[Long] = instance(SqlLong())
-  implicit val doubleType: SqlTypeConversion[Double] = instance(SqlFloat())
+  implicit val doubleType: SqlTypeConversion[Double] = instance(SqlDouble())
   implicit val floatType: SqlTypeConversion[Float] = instance(SqlFloat())
   implicit val bigDecimalType: SqlTypeConversion[BigDecimal] = instance(SqlDecimal())
   implicit val booleanType: SqlTypeConversion[Boolean] = instance(SqlBool())

--- a/core/src/main/scala/org/datatools/bigdatatypes/formats/DefaultTransformKeys.scala
+++ b/core/src/main/scala/org/datatools/bigdatatypes/formats/DefaultTransformKeys.scala
@@ -1,9 +1,12 @@
 package org.datatools.bigdatatypes.formats
 
+//TODO add precision for Decimal types
 trait Formats {
   def transformKeys(s: String): String
 }
 
+/** A list of predefined formats to be imported. Only one can be imported at the same time
+  */
 object Formats {
   implicit val implicitDefaultFormats: Formats = DefaultFormats
   implicit val implicitSnakifyFormats: Formats = SnakifyFormats

--- a/core/src/main/scala/org/datatools/bigdatatypes/types/basic/SqlType.scala
+++ b/core/src/main/scala/org/datatools/bigdatatypes/types/basic/SqlType.scala
@@ -19,6 +19,7 @@ sealed trait SqlType {
         case SqlInt(_)             => SqlInt(mode)
         case SqlLong(_)            => SqlLong(mode)
         case SqlFloat(_)           => SqlFloat(mode)
+        case SqlDouble(_)          => SqlDouble(mode)
         case SqlDecimal(_)         => SqlDecimal(mode)
         case SqlBool(_)            => SqlBool(mode)
         case SqlString(_)          => SqlString(mode)
@@ -33,6 +34,7 @@ sealed trait SqlType {
 case class SqlInt(mode: SqlTypeMode = Required) extends SqlType
 case class SqlLong(mode: SqlTypeMode = Required) extends SqlType
 case class SqlFloat(mode: SqlTypeMode = Required) extends SqlType
+case class SqlDouble(mode: SqlTypeMode = Required) extends SqlType
 case class SqlDecimal(mode: SqlTypeMode = Required) extends SqlType
 case class SqlBool(mode: SqlTypeMode = Required) extends SqlType
 case class SqlString(mode: SqlTypeMode = Required) extends SqlType

--- a/core/src/test/scala/org/datatools/bigdatatypes/TestTypes.scala
+++ b/core/src/test/scala/org/datatools/bigdatatypes/TestTypes.scala
@@ -2,6 +2,25 @@ package org.datatools.bigdatatypes
 
 import java.sql.{Date, Timestamp}
 
+import org.datatools.bigdatatypes.types.basic.{
+  Nullable,
+  Repeated,
+  Required,
+  SqlBool,
+  SqlDate,
+  SqlDecimal,
+  SqlFloat,
+  SqlInt,
+  SqlLong,
+  SqlString,
+  SqlStruct,
+  SqlTimestamp,
+  SqlType
+}
+
+/** Case Classes and their SqlType representations
+  * This should be used to test SqlTypeConversion and all reverse conversions from other modules
+  */
 object TestTypes {
 
   case class BasicTypes(myInt: Int,
@@ -26,4 +45,79 @@ object TestTypes {
   case class Point(x: Int, y: Int)
   case class ListOfStruct(matrix: List[Point])
   case class ExtendedTypes(myInt: Int, myTimestamp: Timestamp, myDate: Date)
+
+  /** Used for case classes, nested or others */
+  val basicFields: List[(String, SqlType)] =
+    List(
+      ("myInt", SqlInt(Required)),
+      ("myLong", SqlLong(Required)),
+      ("myFloat", SqlFloat(Required)),
+      ("myDecimal", SqlDecimal(Required)),
+      ("myBoolean", SqlBool(Required)),
+      ("myString", SqlString(Required))
+    )
+
+  val basicOption: SqlStruct = SqlStruct(
+    List(
+      ("myString", SqlString(Required)),
+      ("myOptionalString", SqlString(Nullable))
+    )
+  )
+
+  val basicTypes: SqlStruct = SqlStruct(basicFields)
+
+  val basicOptionTypes: SqlStruct = SqlStruct(
+    List(
+      ("myInt", SqlInt(Nullable)),
+      ("myLong", SqlLong(Nullable)),
+      ("myFloat", SqlFloat(Nullable)),
+      ("myDecimal", SqlDecimal(Nullable)),
+      ("myBoolean", SqlBool(Nullable)),
+      ("myString", SqlString(Nullable))
+    )
+  )
+
+  val basicWithList: SqlStruct = SqlStruct(
+    List(
+      ("myInt", SqlInt(Required)),
+      ("myList", SqlInt(Repeated))
+    )
+  )
+
+  val basicNested: SqlStruct = SqlStruct(
+    List(
+      ("myInt", SqlInt(Required)),
+      ("myStruct", SqlStruct(basicFields, Required))
+    )
+  )
+
+  val basicOptionalNested: SqlStruct = SqlStruct(
+    List(
+      ("myInt", SqlInt(Required)),
+      ("myStruct", SqlStruct(basicFields, Nullable))
+    )
+  )
+
+  val basicNestedWithList: SqlStruct = SqlStruct(
+    List(
+      (
+        "matrix",
+        SqlStruct(
+          List(
+            ("x", SqlInt(Required)),
+            ("y", SqlInt(Required))
+          ),
+          Repeated
+        )
+      )
+    )
+  )
+
+  val extendedTypes: SqlStruct = SqlStruct(
+    List(
+      ("myInt", SqlInt(Required)),
+      ("myTimestamp", SqlTimestamp(Required)),
+      ("myDate", SqlDate(Required))
+    )
+  )
 }

--- a/core/src/test/scala/org/datatools/bigdatatypes/TestTypes.scala
+++ b/core/src/test/scala/org/datatools/bigdatatypes/TestTypes.scala
@@ -2,21 +2,7 @@ package org.datatools.bigdatatypes
 
 import java.sql.{Date, Timestamp}
 
-import org.datatools.bigdatatypes.types.basic.{
-  Nullable,
-  Repeated,
-  Required,
-  SqlBool,
-  SqlDate,
-  SqlDecimal,
-  SqlFloat,
-  SqlInt,
-  SqlLong,
-  SqlString,
-  SqlStruct,
-  SqlTimestamp,
-  SqlType
-}
+import org.datatools.bigdatatypes.types.basic.{Nullable, Repeated, Required, SqlBool, SqlDate, SqlDecimal, SqlDouble, SqlFloat, SqlInt, SqlLong, SqlString, SqlStruct, SqlTimestamp, SqlType}
 
 /** Case Classes and their SqlType representations
   * This should be used to test SqlTypeConversion and all reverse conversions from other modules
@@ -26,6 +12,7 @@ object TestTypes {
   case class BasicTypes(myInt: Int,
                         myLong: Long,
                         myFloat: Float,
+                        myDouble: Double,
                         myDecimal: BigDecimal,
                         myBoolean: Boolean,
                         myString: String
@@ -34,6 +21,7 @@ object TestTypes {
   case class BasicOptionTypes(myInt: Option[Int],
                               myLong: Option[Long],
                               myFloat: Option[Float],
+                              myDouble: Option[Double],
                               myDecimal: Option[BigDecimal],
                               myBoolean: Option[Boolean],
                               myString: Option[String]
@@ -52,6 +40,7 @@ object TestTypes {
       ("myInt", SqlInt(Required)),
       ("myLong", SqlLong(Required)),
       ("myFloat", SqlFloat(Required)),
+      ("myDouble", SqlDouble(Required)),
       ("myDecimal", SqlDecimal(Required)),
       ("myBoolean", SqlBool(Required)),
       ("myString", SqlString(Required))
@@ -71,6 +60,7 @@ object TestTypes {
       ("myInt", SqlInt(Nullable)),
       ("myLong", SqlLong(Nullable)),
       ("myFloat", SqlFloat(Nullable)),
+      ("myDouble", SqlDouble(Nullable)),
       ("myDecimal", SqlDecimal(Nullable)),
       ("myBoolean", SqlBool(Nullable)),
       ("myString", SqlString(Nullable))

--- a/core/src/test/scala/org/datatools/bigdatatypes/conversions/SqlTypeConversionSpec.scala
+++ b/core/src/test/scala/org/datatools/bigdatatypes/conversions/SqlTypeConversionSpec.scala
@@ -23,9 +23,9 @@ class SqlTypeConversionSpec extends UnitSpec {
     val sqlType: SqlType = SqlTypeConversion[Long].getType
     sqlType shouldBe SqlLong(Required)
   }
-  "Double type" should "be converted into SqlFloat" in {
+  "Double type" should "be converted into SqlDouble" in {
     val sqlType: SqlType = SqlTypeConversion[Double].getType
-    sqlType shouldBe SqlFloat(Required)
+    sqlType shouldBe SqlDouble(Required)
   }
   "Float type" should "be converted into SqlFloat" in {
     val sqlType: SqlType = SqlTypeConversion[Float].getType

--- a/core/src/test/scala/org/datatools/bigdatatypes/conversions/SqlTypeConversionSpec.scala
+++ b/core/src/test/scala/org/datatools/bigdatatypes/conversions/SqlTypeConversionSpec.scala
@@ -51,100 +51,37 @@ class SqlTypeConversionSpec extends UnitSpec {
 
   "Case Class with Option" should "be converted into SqlTypes with nullable" in {
     val sqlType: SqlType = SqlTypeConversion[BasicOption].getType
-    val fields: List[(String, SqlType)] =
-      List(
-        ("myString", SqlString(Required)),
-        ("myOptionalString", SqlString(Nullable))
-      )
-    sqlType shouldBe SqlStruct(fields, Required)
+    sqlType shouldBe basicOption
   }
 
   "basic case class" should "be converted into SqlTypes" in {
     val sqlType: SqlType = SqlTypeConversion[BasicTypes].getType
-    val fields: List[(String, SqlType)] =
-      List(
-        ("myInt", SqlInt(Required)),
-        ("myLong", SqlLong(Required)),
-        ("myFloat", SqlFloat(Required)),
-        ("myDecimal", SqlDecimal(Required)),
-        ("myBoolean", SqlBool(Required)),
-        ("myString", SqlString(Required))
-      )
-    sqlType shouldBe SqlStruct(fields, Required)
+    sqlType shouldBe basicTypes
   }
 
   "Case Class with basic options types" should "be converted into nullable SqlTypes" in {
     val sqlType: SqlType = SqlTypeConversion[BasicOptionTypes].getType
-    val fields: List[(String, SqlType)] =
-      List(
-        ("myInt", SqlInt(Nullable)),
-        ("myLong", SqlLong(Nullable)),
-        ("myFloat", SqlFloat(Nullable)),
-        ("myDecimal", SqlDecimal(Nullable)),
-        ("myBoolean", SqlBool(Nullable)),
-        ("myString", SqlString(Nullable))
-      )
-    sqlType shouldBe SqlStruct(fields, Required)
+    sqlType shouldBe basicOptionTypes
   }
 
   "Case class with List" should "be converted into Repeated type" in {
     val sqlType: SqlType = SqlTypeConversion[BasicList].getType
-    val fields: List[(String, SqlType)] =
-      List(
-        ("myInt", SqlInt(Required)),
-        ("myList", SqlInt(Repeated))
-      )
-    sqlType shouldBe SqlStruct(fields, Required)
+    sqlType shouldBe basicWithList
   }
 
   "case class with nested object" should "be converted into SqlTypes" in {
     val sqlType: SqlType = SqlTypeConversion[BasicStruct].getType
-    val basicFields: List[(String, SqlType)] =
-      List(
-        ("myInt", SqlInt(Required)),
-        ("myLong", SqlLong(Required)),
-        ("myFloat", SqlFloat(Required)),
-        ("myDecimal", SqlDecimal(Required)),
-        ("myBoolean", SqlBool(Required)),
-        ("myString", SqlString(Required))
-      )
-    val fields: List[(String, SqlType)] =
-      List(
-        ("myInt", SqlInt(Required)),
-        ("myStruct", SqlStruct(basicFields, Required))
-      )
-    sqlType shouldBe SqlStruct(fields, Required)
+    sqlType shouldBe basicNested
   }
 
   "case class with optional nested object" should "be converted into SqlTypes" in {
     val sqlType: SqlType = SqlTypeConversion[BasicOptionalStruct].getType
-    val basicFields: List[(String, SqlType)] =
-      List(
-        ("myInt", SqlInt(Required)),
-        ("myLong", SqlLong(Required)),
-        ("myFloat", SqlFloat(Required)),
-        ("myDecimal", SqlDecimal(Required)),
-        ("myBoolean", SqlBool(Required)),
-        ("myString", SqlString(Required))
-      )
-    val fields: List[(String, SqlType)] =
-      List(
-        ("myInt", SqlInt(Required)),
-        ("myStruct", SqlStruct(basicFields, Nullable))
-      )
-    sqlType shouldBe SqlStruct(fields, Required)
+    sqlType shouldBe basicOptionalNested
   }
 
   "Case class with Struct List" should "be converted into Repeated Struct type" in {
     val sqlType: SqlType = SqlTypeConversion[ListOfStruct].getType
-    val struct: List[(String, SqlType)] =
-      List(
-        ("x", SqlInt(Required)),
-        ("y", SqlInt(Required))
-      )
-    val fields: List[(String, SqlType)] =
-      List(("matrix", SqlStruct(struct, Repeated)))
-    sqlType shouldBe SqlStruct(fields, Required)
+    sqlType shouldBe basicNestedWithList
   }
 
   "Option of Option" should "be just a Nullable type mode" in {
@@ -187,13 +124,7 @@ class SqlTypeConversionSpec extends UnitSpec {
 
   "Case class with extended types" should "be converted into Struct with extended types" in {
     val sqlType: SqlType = SqlTypeConversion[ExtendedTypes].getType
-    val fields: List[(String, SqlType)] =
-      List(
-        ("myInt", SqlInt(Required)),
-        ("myTimestamp", SqlTimestamp(Required)),
-        ("myDate", SqlDate(Required))
-      )
-    sqlType shouldBe SqlStruct(fields, Required)
+    sqlType shouldBe extendedTypes
   }
 
 }

--- a/spark/src/main/scala_2.13-/org/datatools/bigdatatypes/spark/SparkTypes.scala
+++ b/spark/src/main/scala_2.13-/org/datatools/bigdatatypes/spark/SparkTypes.scala
@@ -61,6 +61,8 @@ object SparkTypes {
       StructField(name, sparkType(mode, LongType), isNullable(mode))
     case SqlFloat(mode) =>
       StructField(name, sparkType(mode, FloatType), isNullable(mode))
+    case SqlDouble(mode) =>
+      StructField(name, sparkType(mode, DoubleType), isNullable(mode))
     case SqlDecimal(mode) =>
       StructField(name, sparkType(mode, DataTypes.createDecimalType), isNullable(mode))
     case SqlBool(mode) =>

--- a/spark/src/main/scala_2.13-/org/datatools/bigdatatypes/spark/SparkTypes.scala
+++ b/spark/src/main/scala_2.13-/org/datatools/bigdatatypes/spark/SparkTypes.scala
@@ -17,10 +17,9 @@ trait SparkTypes[A] {
     */
   def sparkFields: List[StructField]
 
-  /**
-   * Returns the Spark Schema
-   * @return [[StructType]] with the schema to be used in Spark
-   */
+  /** Returns the Spark Schema
+    * @return [[StructType]] with the schema to be used in Spark
+    */
   def sparkSchema: StructType = StructType(sparkFields)
 }
 
@@ -73,7 +72,7 @@ object SparkTypes {
     case SqlDate(mode) =>
       StructField(name, sparkType(mode, DateType), isNullable(mode))
     case SqlStruct(subType, mode) =>
-      StructField(name, sparkType(mode, StructType(getSchema(SqlStruct(subType)))), isNullable(mode))
+      StructField(name, sparkType(mode, StructType(getSchema(SqlStruct(subType, mode)))), isNullable(mode))
   }
 
   /** Find if a type has to be ArrayType or Basic type

--- a/spark/src/main/scala_2.13-/org/datatools/bigdatatypes/spark/SqlTypeConversionSpark.scala
+++ b/spark/src/main/scala_2.13-/org/datatools/bigdatatypes/spark/SqlTypeConversionSpark.scala
@@ -65,13 +65,12 @@ object SqlTypeConversionSpark {
     def getType: SqlType = structTypeConversion(value).getType
   }
 
-  //TODO change Nullable for a method that converts boolean to Nullable or not
   /** When working with StructFields we already have an instance and not just a type so we need a parameter
     * StructField is being limited to just it's DataType so
     * a StructField("name", IntegerType) will be converted into SqlTypeConversionSpark[IntegerType]
     */
   private def structFieldConversion(sf: StructField): SqlTypeConversionSpark[StructField] =
-    instance(convertSparkType(sf.dataType))
+    instance(convertSparkType(sf.dataType).changeMode(isNullable(sf.nullable)))
 
   //TODO add the rest of the types
   /** Given a Spark DataType, converts it into a SqlType
@@ -87,6 +86,16 @@ object SqlTypeConversionSpark {
     case TimestampType => SqlTimestamp()
     case DateType      => SqlDate()
   }
+
+  /** From Boolean to Nullable or Required Mode
+    */
+  private def isNullable(nullable: Boolean): SqlTypeMode =
+    if (nullable) {
+      Nullable
+    }
+    else {
+      Required
+    }
 
   /** When working with StructTypes we already have an instance and not just a type so we need a parameter,
     * this converts a StructType (or Spark schema) into a SqlStructTypeConversionSpark[StructType]

--- a/spark/src/main/scala_2.13-/org/datatools/bigdatatypes/spark/SqlTypeConversionSpark.scala
+++ b/spark/src/main/scala_2.13-/org/datatools/bigdatatypes/spark/SqlTypeConversionSpark.scala
@@ -66,7 +66,7 @@ object SqlTypeConversionSpark {
     case TimestampType           => SqlTimestamp(isNullable(nullable))
     case DateType                => SqlDate(isNullable(nullable))
     case ArrayType(basicType, _) => convertSparkType(basicType, nullable).changeMode(Repeated)
-    case StructType(fields)    => SqlStruct(loopStructType(StructType(fields)))
+    case StructType(fields)      => SqlStruct(loopStructType(StructType(fields)), isNullable(nullable))
   }
 
   /** From Boolean to Nullable or Required Mode

--- a/spark/src/main/scala_2.13-/org/datatools/bigdatatypes/spark/SqlTypeConversionSpark.scala
+++ b/spark/src/main/scala_2.13-/org/datatools/bigdatatypes/spark/SqlTypeConversionSpark.scala
@@ -56,16 +56,17 @@ object SqlTypeConversionSpark {
   /** Given a Spark DataType, converts it into a SqlType
     */
   private def convertSparkType(dataType: DataType, nullable: Boolean): SqlType = dataType match {
-    case IntegerType => SqlInt(isNullable(nullable))
-    case LongType    => SqlLong(isNullable(nullable))
-    case DoubleType  => SqlFloat(isNullable(nullable))
-    case FloatType   => SqlFloat(isNullable(nullable))
-    //case DecimalType() => SqlDecimal()
-    case BooleanType   => SqlBool(isNullable(nullable))
-    case StringType    => SqlString(isNullable(nullable))
-    case TimestampType => SqlTimestamp(isNullable(nullable))
-    case DateType      => SqlDate(isNullable(nullable))
-    case ArrayType(basicType, _)    => convertSparkType(basicType, nullable).changeMode(Repeated)
+    case IntegerType             => SqlInt(isNullable(nullable))
+    case LongType                => SqlLong(isNullable(nullable))
+    case DoubleType              => SqlFloat(isNullable(nullable))
+    case FloatType               => SqlFloat(isNullable(nullable))
+    case DecimalType()           => SqlDecimal(isNullable(nullable))
+    case BooleanType             => SqlBool(isNullable(nullable))
+    case StringType              => SqlString(isNullable(nullable))
+    case TimestampType           => SqlTimestamp(isNullable(nullable))
+    case DateType                => SqlDate(isNullable(nullable))
+    case ArrayType(basicType, _) => convertSparkType(basicType, nullable).changeMode(Repeated)
+    case StructType(fields)    => SqlStruct(loopStructType(StructType(fields)))
   }
 
   /** From Boolean to Nullable or Required Mode
@@ -91,7 +92,8 @@ object SqlTypeConversionSpark {
   private def loopStructType(st: StructType): List[Record] =
     st.toList match {
       case head +: Seq() => List(head.name -> convertSparkType(head.dataType, head.nullable))
-      case head +: tail =>  List(head.name -> convertSparkType(head.dataType, head.nullable)) ++ loopStructType(StructType(tail))
+      case head +: tail =>
+        List(head.name -> convertSparkType(head.dataType, head.nullable)) ++ loopStructType(StructType(tail))
     }
 
 }

--- a/spark/src/main/scala_2.13-/org/datatools/bigdatatypes/spark/SqlTypeConversionSpark.scala
+++ b/spark/src/main/scala_2.13-/org/datatools/bigdatatypes/spark/SqlTypeConversionSpark.scala
@@ -23,6 +23,7 @@ object SqlTypeConversionSpark {
   implicit val longType: SqlTypeConversion[LongType] = instance(SqlLong())
   implicit val doubleType: SqlTypeConversion[DoubleType] = instance(SqlFloat())
   implicit val floatType: SqlTypeConversion[FloatType] = instance(SqlFloat())
+  //TODO use implicit Formats for default Decimal precision
   //implicit val bigDecimalType: SqlTypeConversion[BigDecimal] = instance(SqlDecimal())
   implicit val booleanType: SqlTypeConversion[BooleanType] = instance(SqlBool())
   implicit val stringType: SqlTypeConversion[StringType] = instance(SqlString())
@@ -84,6 +85,7 @@ object SqlTypeConversionSpark {
     SqlStruct(loopStructType(st))
   )
 
+  //TODO make it tail recursive
   /** Given a StructType, convert it into a List[Record] to be used in a SqlStruct
     */
   private def loopStructType(st: StructType): List[Record] =

--- a/spark/src/main/scala_2.13-/org/datatools/bigdatatypes/spark/SqlTypeConversionSpark.scala
+++ b/spark/src/main/scala_2.13-/org/datatools/bigdatatypes/spark/SqlTypeConversionSpark.scala
@@ -1,0 +1,101 @@
+package org.datatools.bigdatatypes.spark
+
+import java.sql.{Date, Timestamp}
+
+import org.apache.spark.sql.types.{BooleanType, DataType, DateType, DecimalType, DoubleType, FloatType, IntegerType, LongType, StringType, StructField, StructType, TimestampType}
+import org.datatools.bigdatatypes.conversions.{SqlStructTypeConversion, SqlTypeConversion}
+import org.datatools.bigdatatypes.spark.SqlStructTypeConversionSpark.{convertSparkType, instance, structTypeConversion}
+import org.datatools.bigdatatypes.types.basic.{Nullable, Repeated, SqlBool, SqlDate, SqlDecimal, SqlFloat, SqlInt, SqlLong, SqlString, SqlStruct, SqlTimestamp, SqlType}
+import shapeless.labelled.FieldType
+import shapeless.syntax.std.tuple.productTupleOps
+import shapeless.{::, Generic, HList, HNil, Lazy, Witness}
+
+import scala.annotation.tailrec
+
+trait SqlTypeConversionSpark[-A] extends SqlTypeConversion[A]
+
+object SqlTypeConversionSpark {
+
+  /** Summoner method. Allows the syntax
+    * {{{
+    *   val intType = SqlTypeConversion[Int]
+    *   val
+    * }}}
+    */
+  def apply[A](implicit a: SqlTypeConversionSpark[A]): SqlTypeConversionSpark[A] = a
+  def apply(sf: StructField): SqlTypeConversionSpark[StructField] = structFieldConversion(sf)
+  def apply(st: StructType): SqlStructTypeConversionSpark[StructType] = structTypeConversion(st)
+
+  /** Factory constructor - allows easier construction of instances. e.g:
+    * {{{
+    *   val instance = SqlTypeConversion.instance[Option[Int]](SqlInt(Nullable))
+    * }}}
+    */
+  def instance[A](sqlType: SqlType): SqlTypeConversionSpark[A] =
+    new SqlTypeConversionSpark[A] {
+      def getType: SqlType = sqlType
+    }
+
+  implicit val intType: SqlTypeConversionSpark[IntegerType] = instance(SqlInt())
+  implicit val longType: SqlTypeConversionSpark[LongType] = instance(SqlLong())
+  implicit val doubleType: SqlTypeConversionSpark[DoubleType] = instance(SqlFloat())
+  implicit val floatType: SqlTypeConversionSpark[FloatType] = instance(SqlFloat())
+  //implicit val bigDecimalType: SqlTypeConversion[BigDecimal] = instance(SqlDecimal())
+  implicit val booleanType: SqlTypeConversionSpark[BooleanType] = instance(SqlBool())
+  implicit val stringType: SqlTypeConversionSpark[StringType] = instance(SqlString())
+  // Extended types
+  implicit val timestampType: SqlTypeConversionSpark[TimestampType] = instance(SqlTimestamp())
+  implicit val dateType: SqlTypeConversionSpark[DateType] = instance(SqlDate())
+
+  implicit def listLikeType[A](implicit cnv: SqlTypeConversionSpark[A]): SqlTypeConversionSpark[Iterable[A]] =
+    instance(cnv.getType.changeMode(Repeated))
+
+  //TODO change Nullable for a method that converts boolean to Nullable or not
+  def structFieldConversion[A](sf: StructField): SqlTypeConversionSpark[StructField] =
+    instance(convertSparkType(sf.dataType))
+
+}
+
+trait SqlStructTypeConversionSpark[A] extends SqlStructTypeConversion[A]
+
+object SqlStructTypeConversionSpark {
+  type Record = (String, SqlType)
+
+  /** Summoner method */
+  def apply[A](implicit instance: SqlStructTypeConversionSpark[A]): SqlStructTypeConversionSpark[A] = instance
+
+  //TODO add the rest of the types
+  def convertSparkType(dataType: DataType): SqlType = dataType match {
+    case IntegerType => SqlInt()
+    case LongType    => SqlLong()
+    case DoubleType  => SqlFloat()
+    case FloatType   => SqlFloat()
+    //case DecimalType() => SqlDecimal()
+    case BooleanType   => SqlBool()
+    case StringType    => SqlString()
+    case TimestampType => SqlTimestamp()
+    case DateType      => SqlDate()
+  }
+
+  /** Factory constructor */
+  def instance[A](record: SqlStruct): SqlStructTypeConversionSpark[A] =
+    new SqlStructTypeConversionSpark[A] {
+      def getType: SqlStruct = record
+    }
+
+  /**
+    * Without implicits for StructTypes, this converts a StructType (or Spark schema) into a
+    * SqlStructTypeConversionSpark[StructType]
+    */
+  def structTypeConversion(st: StructType): SqlStructTypeConversionSpark[StructType] = instance(SqlStruct(loopStructType(st), Nullable))
+
+
+  /**
+    * Given a StructType, convert it into a List[Record] to be used in a SqlStruct
+    */
+  private def loopStructType(st: StructType): List[Record] =
+    st.toList match {
+      case head +: Seq() => List(head.name -> convertSparkType(head.dataType))
+      case head +: tail  => List(head.name -> convertSparkType(head.dataType)) ++ loopStructType(StructType(tail))
+    }
+}

--- a/spark/src/main/scala_2.13-/org/datatools/bigdatatypes/spark/SqlTypeConversionSpark.scala
+++ b/spark/src/main/scala_2.13-/org/datatools/bigdatatypes/spark/SqlTypeConversionSpark.scala
@@ -19,11 +19,10 @@ object SqlTypeConversionSpark {
     */
   def apply(sf: StructField): SqlTypeConversion[StructField] = structFieldConversion(sf)
   def apply(st: StructType): SqlTypeConversion[StructType] = structTypeConversion(st)
-  def apply(st: List[StructField]): SqlTypeConversion[StructType] = structTypeConversion(StructType(st))
 
   implicit val intType: SqlTypeConversion[IntegerType] = instance(SqlInt())
   implicit val longType: SqlTypeConversion[LongType] = instance(SqlLong())
-  implicit val doubleType: SqlTypeConversion[DoubleType] = instance(SqlFloat())
+  implicit val doubleType: SqlTypeConversion[DoubleType] = instance(SqlDouble())
   implicit val floatType: SqlTypeConversion[FloatType] = instance(SqlFloat())
   //TODO use implicit Formats for default Decimal precision
   implicit val bigDecimalType: SqlTypeConversion[BigDecimal] = instance(SqlDecimal())
@@ -64,7 +63,7 @@ object SqlTypeConversionSpark {
   ): SqlType = dataType match {
     case IntegerType             => SqlInt(inheritMode.getOrElse(isNullable(nullable)))
     case LongType                => SqlLong(inheritMode.getOrElse(isNullable(nullable)))
-    case DoubleType              => SqlFloat(inheritMode.getOrElse(isNullable(nullable)))
+    case DoubleType              => SqlDouble(inheritMode.getOrElse(isNullable(nullable)))
     case FloatType               => SqlFloat(inheritMode.getOrElse(isNullable(nullable)))
     case DecimalType()           => SqlDecimal(inheritMode.getOrElse(isNullable(nullable)))
     case BooleanType             => SqlBool(inheritMode.getOrElse(isNullable(nullable)))

--- a/spark/src/main/scala_2.13-/org/datatools/bigdatatypes/spark/SqlTypeConversionSpark.scala
+++ b/spark/src/main/scala_2.13-/org/datatools/bigdatatypes/spark/SqlTypeConversionSpark.scala
@@ -70,21 +70,21 @@ object SqlTypeConversionSpark {
     * a StructField("name", IntegerType) will be converted into SqlTypeConversionSpark[IntegerType]
     */
   private def structFieldConversion(sf: StructField): SqlTypeConversionSpark[StructField] =
-    instance(convertSparkType(sf.dataType).changeMode(isNullable(sf.nullable)))
+    instance(convertSparkType(sf.dataType, sf.nullable))
 
   //TODO add the rest of the types
   /** Given a Spark DataType, converts it into a SqlType
     */
-  private def convertSparkType(dataType: DataType): SqlType = dataType match {
-    case IntegerType => SqlInt()
-    case LongType    => SqlLong()
-    case DoubleType  => SqlFloat()
-    case FloatType   => SqlFloat()
+  private def convertSparkType(dataType: DataType, nullable: Boolean): SqlType = dataType match {
+    case IntegerType => SqlInt(isNullable(nullable))
+    case LongType    => SqlLong(isNullable(nullable))
+    case DoubleType  => SqlFloat(isNullable(nullable))
+    case FloatType   => SqlFloat(isNullable(nullable))
     //case DecimalType() => SqlDecimal()
-    case BooleanType   => SqlBool()
-    case StringType    => SqlString()
-    case TimestampType => SqlTimestamp()
-    case DateType      => SqlDate()
+    case BooleanType   => SqlBool(isNullable(nullable))
+    case StringType    => SqlString(isNullable(nullable))
+    case TimestampType => SqlTimestamp(isNullable(nullable))
+    case DateType      => SqlDate(isNullable(nullable))
   }
 
   /** From Boolean to Nullable or Required Mode
@@ -101,15 +101,15 @@ object SqlTypeConversionSpark {
     * this converts a StructType (or Spark schema) into a SqlStructTypeConversionSpark[StructType]
     */
   private def structTypeConversion(st: StructType): SqlTypeConversionSpark[StructType] = instance(
-    SqlStruct(loopStructType(st), Nullable)
+    SqlStruct(loopStructType(st))
   )
 
   /** Given a StructType, convert it into a List[Record] to be used in a SqlStruct
     */
   private def loopStructType(st: StructType): List[Record] =
     st.toList match {
-      case head +: Seq() => List(head.name -> convertSparkType(head.dataType))
-      case head +: tail  => List(head.name -> convertSparkType(head.dataType)) ++ loopStructType(StructType(tail))
+      case head +: Seq() => List(head.name -> convertSparkType(head.dataType, head.nullable))
+      case head +: tail  => List(head.name -> convertSparkType(head.dataType, head.nullable)) ++ loopStructType(StructType(tail))
     }
 
 }

--- a/spark/src/test/scala_2.13-/org/datatools/bigdatatypes/spark/SparkTypesSpec.scala
+++ b/spark/src/test/scala_2.13-/org/datatools/bigdatatypes/spark/SparkTypesSpec.scala
@@ -39,6 +39,7 @@ class SparkTypesSpec extends UnitSpec {
         StructField("myInt", IntegerType, nullable = false),
         StructField("myLong", LongType, nullable = false),
         StructField("myFloat", FloatType, nullable = false),
+        StructField("myDouble", DoubleType, nullable = false),
         StructField("myDecimal", DataTypes.createDecimalType, nullable = false),
         StructField("myBoolean", BooleanType, nullable = false),
         StructField("myString", StringType, nullable = false)
@@ -54,6 +55,7 @@ class SparkTypesSpec extends UnitSpec {
         StructField("myInt", IntegerType, nullable = true),
         StructField("myLong", LongType, nullable = true),
         StructField("myFloat", FloatType, nullable = true),
+        StructField("myDouble", DoubleType, nullable = true),
         StructField("myDecimal", DataTypes.createDecimalType, nullable = true),
         StructField("myBoolean", BooleanType, nullable = true),
         StructField("myString", StringType, nullable = true)
@@ -81,6 +83,7 @@ class SparkTypesSpec extends UnitSpec {
               StructField("myInt", IntegerType, nullable = false),
               StructField("myLong", LongType, nullable = false),
               StructField("myFloat", FloatType, nullable = false),
+              StructField("myDouble", DoubleType, nullable = false),
               StructField("myDecimal", DataTypes.createDecimalType, nullable = false),
               StructField("myBoolean", BooleanType, nullable = false),
               StructField("myString", StringType, nullable = false)
@@ -102,6 +105,7 @@ class SparkTypesSpec extends UnitSpec {
               StructField("myInt", IntegerType, nullable = false),
               StructField("myLong", LongType, nullable = false),
               StructField("myFloat", FloatType, nullable = false),
+              StructField("myDouble", DoubleType, nullable = false),
               StructField("myDecimal", DataTypes.createDecimalType, nullable = false),
               StructField("myBoolean", BooleanType, nullable = false),
               StructField("myString", StringType, nullable = false)

--- a/spark/src/test/scala_2.13-/org/datatools/bigdatatypes/spark/SqlTypeConversionSparkSpec.scala
+++ b/spark/src/test/scala_2.13-/org/datatools/bigdatatypes/spark/SqlTypeConversionSparkSpec.scala
@@ -35,7 +35,7 @@ class SqlTypeConversionSparkSpec extends UnitSpec {
 
   "SparkSchema from Case Class" should "be converted into SqlStruct" in {
     case class Dummy(myInt: Int, myString: String)
-    val expected = SqlStruct(List(("myInt", SqlInt()), ("myString", SqlString())), Nullable)
+    val expected = SqlStruct(List(("myInt", SqlInt()), ("myString", SqlString())))
     SqlTypeConversionSpark(SparkTypes[Dummy].sparkSchema).getType shouldBe expected
   }
 

--- a/spark/src/test/scala_2.13-/org/datatools/bigdatatypes/spark/SqlTypeConversionSparkSpec.scala
+++ b/spark/src/test/scala_2.13-/org/datatools/bigdatatypes/spark/SqlTypeConversionSparkSpec.scala
@@ -2,6 +2,7 @@ package org.datatools.bigdatatypes.spark
 
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
 import org.datatools.bigdatatypes.UnitSpec
+import org.datatools.bigdatatypes.conversions.SqlTypeConversion
 import org.datatools.bigdatatypes.formats.Formats.implicitDefaultFormats
 import org.datatools.bigdatatypes.spark.SqlTypeConversionSpark._
 import org.datatools.bigdatatypes.types.basic.{Nullable, Required, SqlInt, SqlString, SqlStruct}
@@ -9,12 +10,12 @@ import org.datatools.bigdatatypes.types.basic.{Nullable, Required, SqlInt, SqlSt
 class SqlTypeConversionSparkSpec extends UnitSpec {
 
   "Simple Spark DataType" should "be converted into SqlType" in {
-    SqlTypeConversionSpark[IntegerType].getType shouldBe SqlInt()
+    SqlTypeConversion[IntegerType].getType shouldBe SqlInt()
   }
 
   "StructField nullable" should "be converted into Nullable SqlType" in {
     val sf = StructField("myInt", IntegerType, nullable = true)
-    sf.getType shouldBe SqlInt()
+    sf.getType shouldBe SqlInt(Nullable)
     SqlTypeConversionSpark(sf).getType shouldBe SqlInt(Nullable)
   }
 
@@ -28,7 +29,7 @@ class SqlTypeConversionSparkSpec extends UnitSpec {
     val sf = StructField("myInt", IntegerType, nullable = false)
     val sf2 = StructField("myString", StringType, nullable = true)
     val st = StructType(List(sf, sf2))
-    val expected = SqlStruct(List(("myInt", SqlInt()), ("myString", SqlString(Nullable))), Nullable)
+    val expected = SqlStruct(List(("myInt", SqlInt()), ("myString", SqlString(Nullable))))
     SqlTypeConversionSpark(st).getType shouldBe expected
     st.getType shouldBe expected
   }

--- a/spark/src/test/scala_2.13-/org/datatools/bigdatatypes/spark/SqlTypeConversionSparkSpec.scala
+++ b/spark/src/test/scala_2.13-/org/datatools/bigdatatypes/spark/SqlTypeConversionSparkSpec.scala
@@ -3,6 +3,7 @@ package org.datatools.bigdatatypes.spark
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
 import org.datatools.bigdatatypes.UnitSpec
 import org.datatools.bigdatatypes.formats.Formats.implicitDefaultFormats
+import org.datatools.bigdatatypes.spark.SqlTypeConversionSpark._
 import org.datatools.bigdatatypes.types.basic.{Nullable, SqlInt, SqlString, SqlStruct}
 
 class SqlTypeConversionSparkSpec extends UnitSpec {
@@ -13,6 +14,7 @@ class SqlTypeConversionSparkSpec extends UnitSpec {
 
   "StructField" should "be converted into SqlType" in {
     val sf = StructField("myInt", IntegerType, nullable = false)
+    sf.getType shouldBe SqlInt()
     SqlTypeConversionSpark(sf).getType shouldBe SqlInt()
   }
 
@@ -22,6 +24,7 @@ class SqlTypeConversionSparkSpec extends UnitSpec {
     val st = StructType(List(sf, sf2))
     val expected = SqlStruct(List(("myInt", SqlInt()), ("myString", SqlString())), Nullable)
     SqlTypeConversionSpark(st).getType shouldBe expected
+    st.getType shouldBe expected
   }
 
   "SparkSchema from Case Class" should "be converted into SqlStruct" in {

--- a/spark/src/test/scala_2.13-/org/datatools/bigdatatypes/spark/SqlTypeConversionSparkSpec.scala
+++ b/spark/src/test/scala_2.13-/org/datatools/bigdatatypes/spark/SqlTypeConversionSparkSpec.scala
@@ -6,7 +6,7 @@ import org.datatools.bigdatatypes.UnitSpec
 import org.datatools.bigdatatypes.conversions.SqlTypeConversion
 import org.datatools.bigdatatypes.formats.Formats.implicitDefaultFormats
 import org.datatools.bigdatatypes.spark.SqlTypeConversionSpark._
-import org.datatools.bigdatatypes.types.basic.{Nullable, Repeated, Required, SqlInt, SqlString, SqlStruct, SqlType}
+import org.datatools.bigdatatypes.types.basic.{Nullable, Required, SqlInt, SqlString, SqlStruct, SqlType}
 
 class SqlTypeConversionSparkSpec extends UnitSpec {
 
@@ -63,7 +63,6 @@ class SqlTypeConversionSparkSpec extends UnitSpec {
   }
 
   "Spark Schema with optional nested object" should "be converted into SqlTypes" in {
-    println(SparkTypes[BasicOptionalStruct].sparkSchema)
     val sqlType: SqlType = SparkTypes[BasicOptionalStruct].sparkSchema.getType
     sqlType shouldBe basicOptionalNested
   }

--- a/spark/src/test/scala_2.13-/org/datatools/bigdatatypes/spark/SqlTypeConversionSparkSpec.scala
+++ b/spark/src/test/scala_2.13-/org/datatools/bigdatatypes/spark/SqlTypeConversionSparkSpec.scala
@@ -5,7 +5,7 @@ import org.datatools.bigdatatypes.UnitSpec
 import org.datatools.bigdatatypes.conversions.SqlTypeConversion
 import org.datatools.bigdatatypes.formats.Formats.implicitDefaultFormats
 import org.datatools.bigdatatypes.spark.SqlTypeConversionSpark._
-import org.datatools.bigdatatypes.types.basic.{Nullable, Required, SqlInt, SqlString, SqlStruct}
+import org.datatools.bigdatatypes.types.basic.{Nullable, Repeated, Required, SqlInt, SqlString, SqlStruct}
 
 class SqlTypeConversionSparkSpec extends UnitSpec {
 
@@ -38,6 +38,13 @@ class SqlTypeConversionSparkSpec extends UnitSpec {
     case class Dummy(myInt: Int, myString: String)
     val expected = SqlStruct(List(("myInt", SqlInt()), ("myString", SqlString())))
     SqlTypeConversionSpark(SparkTypes[Dummy].sparkSchema).getType shouldBe expected
+  }
+
+  "StructType with Arrays" should "be converted into SqlStruct with Repeated" in {
+    case class Dummy(myString: String, myList: List[Int])
+    val schema = SparkTypes[Dummy].sparkSchema
+    val expected = SqlStruct(List(("myString", SqlString()), ("myList", SqlInt(Repeated))))
+    schema.getType shouldBe expected
   }
 
 }

--- a/spark/src/test/scala_2.13-/org/datatools/bigdatatypes/spark/SqlTypeConversionSparkSpec.scala
+++ b/spark/src/test/scala_2.13-/org/datatools/bigdatatypes/spark/SqlTypeConversionSparkSpec.scala
@@ -1,11 +1,12 @@
 package org.datatools.bigdatatypes.spark
 
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
+import org.datatools.bigdatatypes.TestTypes._
 import org.datatools.bigdatatypes.UnitSpec
 import org.datatools.bigdatatypes.conversions.SqlTypeConversion
 import org.datatools.bigdatatypes.formats.Formats.implicitDefaultFormats
 import org.datatools.bigdatatypes.spark.SqlTypeConversionSpark._
-import org.datatools.bigdatatypes.types.basic.{Nullable, Repeated, Required, SqlInt, SqlString, SqlStruct}
+import org.datatools.bigdatatypes.types.basic.{Nullable, Repeated, Required, SqlInt, SqlString, SqlStruct, SqlType}
 
 class SqlTypeConversionSparkSpec extends UnitSpec {
 
@@ -46,5 +47,49 @@ class SqlTypeConversionSparkSpec extends UnitSpec {
     val expected = SqlStruct(List(("myString", SqlString()), ("myList", SqlInt(Repeated))))
     schema.getType shouldBe expected
   }
+
+  behavior of "Common Test Types for Spark"
+
+  "Spark Schema with Option" should "be converted into SqlTypes with nullable" in {
+    val sqlType: SqlType = SparkTypes[BasicOption].sparkSchema.getType
+    sqlType shouldBe basicOption
+  }
+
+  "basic Spark Schema" should "be converted into SqlTypes" in {
+    val sqlType: SqlType = SparkTypes[BasicTypes].sparkSchema.getType
+    sqlType shouldBe basicTypes
+  }
+
+  "Spark Schema with basic options types" should "be converted into nullable SqlTypes" in {
+    val sqlType: SqlType = SparkTypes[BasicOptionTypes].sparkSchema.getType
+    sqlType shouldBe basicOptionTypes
+  }
+
+  "Spark Schema with List" should "be converted into Repeated type" in {
+    val sqlType: SqlType = SparkTypes[BasicList].sparkSchema.getType
+    sqlType shouldBe basicWithList
+  }
+
+  "Spark Schema with nested object" should "be converted into SqlTypes" in {
+    val sqlType: SqlType = SparkTypes[BasicStruct].sparkSchema.getType
+    sqlType shouldBe basicNested
+  }
+
+  "Spark Schema with optional nested object" should "be converted into SqlTypes" in {
+    println(SparkTypes[BasicOptionalStruct].sparkSchema)
+    val sqlType: SqlType = SparkTypes[BasicOptionalStruct].sparkSchema.getType
+    sqlType shouldBe basicOptionalNested
+  }
+
+  "Spark Schema with Struct List" should "be converted into Repeated Struct type" in {
+    val sqlType: SqlType = SparkTypes[ListOfStruct].sparkSchema.getType
+    sqlType shouldBe basicNestedWithList
+  }
+
+  "Spark Schema with extended types" should "be converted into Struct with extended types" in {
+    val sqlType: SqlType = SparkTypes[ExtendedTypes].sparkSchema.getType
+    sqlType shouldBe extendedTypes
+  }
+
 
 }

--- a/spark/src/test/scala_2.13-/org/datatools/bigdatatypes/spark/SqlTypeConversionSparkSpec.scala
+++ b/spark/src/test/scala_2.13-/org/datatools/bigdatatypes/spark/SqlTypeConversionSparkSpec.scala
@@ -1,0 +1,26 @@
+package org.datatools.bigdatatypes.spark
+
+import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
+import org.datatools.bigdatatypes.UnitSpec
+import org.datatools.bigdatatypes.formats.Formats.implicitDefaultFormats
+
+class SqlTypeConversionSparkSpec extends UnitSpec {
+
+  "test" should "test" in {
+
+    case class Dummy(myInt: Int, myString: String)
+    println(SqlTypeConversionSpark[IntegerType].getType)
+    val sf = StructField("myString", StringType, nullable = false)
+    val sf2 = StructField("myInt", IntegerType, nullable = true)
+    val st = StructType(List(sf))
+    val st2 = StructType(List(sf, sf))
+    val st3 = StructType(List(sf, sf2))
+    println(SqlTypeConversionSpark[IntegerType].getType)
+    println(SqlTypeConversionSpark(sf).getType)
+    println(SqlTypeConversionSpark(st).getType)
+    println(SqlTypeConversionSpark(st2).getType)
+    println(SqlTypeConversionSpark(st3).getType)
+    println(SqlTypeConversionSpark(SparkTypes[Dummy].sparkSchema).getType)
+  }
+
+}

--- a/spark/src/test/scala_2.13-/org/datatools/bigdatatypes/spark/SqlTypeConversionSparkSpec.scala
+++ b/spark/src/test/scala_2.13-/org/datatools/bigdatatypes/spark/SqlTypeConversionSparkSpec.scala
@@ -4,7 +4,7 @@ import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructT
 import org.datatools.bigdatatypes.UnitSpec
 import org.datatools.bigdatatypes.formats.Formats.implicitDefaultFormats
 import org.datatools.bigdatatypes.spark.SqlTypeConversionSpark._
-import org.datatools.bigdatatypes.types.basic.{Nullable, SqlInt, SqlString, SqlStruct}
+import org.datatools.bigdatatypes.types.basic.{Nullable, Required, SqlInt, SqlString, SqlStruct}
 
 class SqlTypeConversionSparkSpec extends UnitSpec {
 
@@ -12,17 +12,23 @@ class SqlTypeConversionSparkSpec extends UnitSpec {
     SqlTypeConversionSpark[IntegerType].getType shouldBe SqlInt()
   }
 
-  "StructField" should "be converted into SqlType" in {
+  "StructField nullable" should "be converted into Nullable SqlType" in {
+    val sf = StructField("myInt", IntegerType, nullable = true)
+    sf.getType shouldBe SqlInt()
+    SqlTypeConversionSpark(sf).getType shouldBe SqlInt(Nullable)
+  }
+
+  "StructField required" should "be converted into Required SqlType" in {
     val sf = StructField("myInt", IntegerType, nullable = false)
     sf.getType shouldBe SqlInt()
-    SqlTypeConversionSpark(sf).getType shouldBe SqlInt()
+    SqlTypeConversionSpark(sf).getType shouldBe SqlInt(Required)
   }
 
   "StructType" should "be converted into SqlStruct" in {
     val sf = StructField("myInt", IntegerType, nullable = false)
-    val sf2 = StructField("myString", StringType, nullable = false)
+    val sf2 = StructField("myString", StringType, nullable = true)
     val st = StructType(List(sf, sf2))
-    val expected = SqlStruct(List(("myInt", SqlInt()), ("myString", SqlString())), Nullable)
+    val expected = SqlStruct(List(("myInt", SqlInt()), ("myString", SqlString(Nullable))), Nullable)
     SqlTypeConversionSpark(st).getType shouldBe expected
     st.getType shouldBe expected
   }

--- a/spark/src/test/scala_2.13-/org/datatools/bigdatatypes/spark/SqlTypeConversionSparkSpec.scala
+++ b/spark/src/test/scala_2.13-/org/datatools/bigdatatypes/spark/SqlTypeConversionSparkSpec.scala
@@ -35,19 +35,6 @@ class SqlTypeConversionSparkSpec extends UnitSpec {
     st.getType shouldBe expected
   }
 
-  "SparkSchema from Case Class" should "be converted into SqlStruct" in {
-    case class Dummy(myInt: Int, myString: String)
-    val expected = SqlStruct(List(("myInt", SqlInt()), ("myString", SqlString())))
-    SqlTypeConversionSpark(SparkTypes[Dummy].sparkSchema).getType shouldBe expected
-  }
-
-  "StructType with Arrays" should "be converted into SqlStruct with Repeated" in {
-    case class Dummy(myString: String, myList: List[Int])
-    val schema = SparkTypes[Dummy].sparkSchema
-    val expected = SqlStruct(List(("myString", SqlString()), ("myList", SqlInt(Repeated))))
-    schema.getType shouldBe expected
-  }
-
   behavior of "Common Test Types for Spark"
 
   "Spark Schema with Option" should "be converted into SqlTypes with nullable" in {

--- a/spark/src/test/scala_2.13-/org/datatools/bigdatatypes/spark/SqlTypeConversionSparkSpec.scala
+++ b/spark/src/test/scala_2.13-/org/datatools/bigdatatypes/spark/SqlTypeConversionSparkSpec.scala
@@ -3,24 +3,31 @@ package org.datatools.bigdatatypes.spark
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
 import org.datatools.bigdatatypes.UnitSpec
 import org.datatools.bigdatatypes.formats.Formats.implicitDefaultFormats
+import org.datatools.bigdatatypes.types.basic.{Nullable, SqlInt, SqlString, SqlStruct}
 
 class SqlTypeConversionSparkSpec extends UnitSpec {
 
-  "test" should "test" in {
+  "Simple Spark DataType" should "be converted into SqlType" in {
+    SqlTypeConversionSpark[IntegerType].getType shouldBe SqlInt()
+  }
 
+  "StructField" should "be converted into SqlType" in {
+    val sf = StructField("myInt", IntegerType, nullable = false)
+    SqlTypeConversionSpark(sf).getType shouldBe SqlInt()
+  }
+
+  "StructType" should "be converted into SqlStruct" in {
+    val sf = StructField("myInt", IntegerType, nullable = false)
+    val sf2 = StructField("myString", StringType, nullable = false)
+    val st = StructType(List(sf, sf2))
+    val expected = SqlStruct(List(("myInt", SqlInt()), ("myString", SqlString())), Nullable)
+    SqlTypeConversionSpark(st).getType shouldBe expected
+  }
+
+  "SparkSchema from Case Class" should "be converted into SqlStruct" in {
     case class Dummy(myInt: Int, myString: String)
-    println(SqlTypeConversionSpark[IntegerType].getType)
-    val sf = StructField("myString", StringType, nullable = false)
-    val sf2 = StructField("myInt", IntegerType, nullable = true)
-    val st = StructType(List(sf))
-    val st2 = StructType(List(sf, sf))
-    val st3 = StructType(List(sf, sf2))
-    println(SqlTypeConversionSpark[IntegerType].getType)
-    println(SqlTypeConversionSpark(sf).getType)
-    println(SqlTypeConversionSpark(st).getType)
-    println(SqlTypeConversionSpark(st2).getType)
-    println(SqlTypeConversionSpark(st3).getType)
-    println(SqlTypeConversionSpark(SparkTypes[Dummy].sparkSchema).getType)
+    val expected = SqlStruct(List(("myInt", SqlInt()), ("myString", SqlString())), Nullable)
+    SqlTypeConversionSpark(SparkTypes[Dummy].sparkSchema).getType shouldBe expected
   }
 
 }


### PR DESCRIPTION
This PR aims to:

- Add a "reverse conversion" for Spark (from Spark Schemas to SqlTypes)
- Refactor SqlTypeConversion to have another situation, when a conversion starts from an instance, not from a Type 