### PR TITLE
BigQuery => SqlType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### Big Data Types v0.5.0
+- BigQuery: Reverse conversion. 
+  This allows any BigQuery object (Schema or Field) to be converted into any of the other implemented types
+- Upgrade to Scala 3.0.1
+
 ### Big Data Types v0.4.0
 - Cassandra module added
 - More cross examples added

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Available conversions:
 | From / To  |Scala Types       |BigQuery          |Spark             |Cassandra         |
 |------------|:----------------:|:----------------:|:----------------:|:----------------:|
 |Scala Types |       -          |:white_check_mark:|:white_check_mark:|:white_check_mark:|
-|BigQuery    |                  |        -         |                  |                  |
+|BigQuery    |                  |        -         |:white_check_mark:|:white_check_mark:|
 |Spark       |                  |:white_check_mark:|        -         |:white_check_mark:|
 |Cassandra   |                  |                  |                  |        -         |
 

--- a/bigquery/src/main/scala/org/datatools/bigdatatypes/bigquery/BigQueryTypeConversion.scala
+++ b/bigquery/src/main/scala/org/datatools/bigdatatypes/bigquery/BigQueryTypeConversion.scala
@@ -1,0 +1,84 @@
+package org.datatools.bigdatatypes.bigquery
+
+import com.google.cloud.bigquery.{Field, FieldList, LegacySQLTypeName, Schema, StandardSQLTypeName}
+import org.datatools.bigdatatypes.basictypes.SqlType._
+import org.datatools.bigdatatypes.basictypes.SqlTypeMode._
+import org.datatools.bigdatatypes.basictypes._
+import org.datatools.bigdatatypes.bigquery.JavaConverters.toScala
+import org.datatools.bigdatatypes.bigquery.SqlTypeToBigQuery.{getSchema, sqlModeToBigQueryMode}
+import org.datatools.bigdatatypes.conversions.{SqlInstanceConversion, SqlTypeConversion}
+import org.datatools.bigdatatypes.formats.Formats
+
+import scala.annotation.tailrec
+
+/** Using SqlTypeConversion and SqlInstanceConversion type classes,
+  * here are defined all the conversions to transform BigQuery Tables into [[SqlType]]s
+  */
+object BigQueryTypeConversion {
+
+  type Record = (String, SqlType)
+
+  /** SqlTypeConversion type class specifications for simple types
+    */
+  implicit val intType: SqlTypeConversion[StandardSQLTypeName.INT64.type] = SqlTypeConversion.instance(SqlLong())
+  implicit val floatType: SqlTypeConversion[StandardSQLTypeName.FLOAT64.type] = SqlTypeConversion.instance(SqlFloat())
+  implicit val bigDecimalType: SqlTypeConversion[StandardSQLTypeName.NUMERIC.type] =  SqlTypeConversion.instance(SqlDecimal())
+  implicit val booleanType: SqlTypeConversion[StandardSQLTypeName.BOOL.type] = SqlTypeConversion.instance(SqlBool())
+  implicit val stringType: SqlTypeConversion[StandardSQLTypeName.STRING.type] = SqlTypeConversion.instance(SqlString())
+
+  // Extended types
+  implicit val timestampType: SqlTypeConversion[StandardSQLTypeName.TIMESTAMP.type] = SqlTypeConversion.instance(SqlTimestamp())
+  implicit val dateType: SqlTypeConversion[StandardSQLTypeName.DATE.type] = SqlTypeConversion.instance(SqlDate())
+
+  /** SqlInstanceConversion type class specifications for Field and Schema instances
+    */
+  implicit val schema: SqlInstanceConversion[Schema] =
+    (value: Schema) => SqlStruct(loopSchemaType(value.getFields))
+
+  implicit val field: SqlInstanceConversion[Field] =
+    (value: Field) => SqlStruct(loopSchemaType(value.getSubFields))
+
+
+  /** Extension methods for BigQuery Schemas and Fields into SqlTypes */
+
+  /** Extension method. Enables val myInstance: Field -> myInstance.getType syntax
+    */
+  implicit class StructTypeSyntax(value: Field) {
+    def getType: SqlType = SqlInstanceConversion[Field].getType(value)
+  }
+
+  /** Extension method. Enables myBQTable: Schema -> myBQTable.getType */
+  implicit class StructFieldSyntax(value: Schema) {
+    def getType: SqlType = SqlInstanceConversion[Schema].getType(value)
+  }
+
+  /** Given a BigQuery Field, converts it into a SqlType
+    */
+  private def convertBigQueryType(field: Field): SqlType =
+    field.getType match {
+      case LegacySQLTypeName.INTEGER   => SqlLong(findMode(field.getMode)) //BigQuery only has Int64
+      case LegacySQLTypeName.FLOAT     => SqlFloat(findMode(field.getMode))
+      case LegacySQLTypeName.NUMERIC   => SqlDecimal(findMode(field.getMode))
+      case LegacySQLTypeName.BOOLEAN   => SqlBool(findMode(field.getMode))
+      case LegacySQLTypeName.STRING    => SqlString(findMode(field.getMode))
+      case LegacySQLTypeName.TIMESTAMP => SqlTimestamp(findMode(field.getMode))
+      case LegacySQLTypeName.DATE      => SqlDate(findMode(field.getMode))
+      case LegacySQLTypeName.RECORD    => SqlStruct(loopSchemaType(field.getSubFields), findMode(field.getMode))
+    }
+
+  /** Maps Field.Mode to our custom Mode
+    */
+  private def findMode(mode: Field.Mode): SqlTypeMode =
+    mode match {
+      case Field.Mode.NULLABLE => Nullable
+      case Field.Mode.REQUIRED => Required
+      case Field.Mode.REPEATED => Repeated
+    }
+
+  /** Given a FieldList (from a [[Field]] or from a [[Schema]]), converts it into a List[Record] to be used in a SqlStruct
+    */
+  private def loopSchemaType(fields: FieldList): List[Record] =
+    toScala(fields).map { field =>
+      field.getName -> convertBigQueryType(field)
+    }
+}

--- a/bigquery/src/main/scala_2.13+/org/datatools/bigdatatypes/bigquery/JavaConverters.scala
+++ b/bigquery/src/main/scala_2.13+/org/datatools/bigdatatypes/bigquery/JavaConverters.scala
@@ -1,10 +1,10 @@
 package org.datatools.bigdatatypes.bigquery
 
 import java.lang
-
-import scala.jdk.CollectionConverters.IterableHasAsJava
+import scala.jdk.CollectionConverters.{IterableHasAsJava, IterableHasAsScala}
 
 object JavaConverters {
 
   def toJava[A](value: List[A]): lang.Iterable[A] = value.asJava
+  def toScala[A](value: lang.Iterable[A]): List[A] = value.asScala.toList
 }

--- a/bigquery/src/main/scala_2.13-/org/datatools/bigdatatypes/bigquery/JavaConverters.scala
+++ b/bigquery/src/main/scala_2.13-/org/datatools/bigdatatypes/bigquery/JavaConverters.scala
@@ -1,10 +1,10 @@
 package org.datatools.bigdatatypes.bigquery
 
 import java.lang
-
-import scala.collection.JavaConverters.asJavaIterableConverter
+import scala.collection.JavaConverters.{asJavaIterableConverter, iterableAsScalaIterableConverter}
 
 object JavaConverters {
 
   def toJava[A](value: List[A]): lang.Iterable[A] = value.asJava
+  def toScala[A](value: lang.Iterable[A]): List[A] = value.asScala.toList
 }

--- a/bigquery/src/test/scala/org/datatools/bigdatatypes/BigQueryTestTypes.scala
+++ b/bigquery/src/test/scala/org/datatools/bigdatatypes/BigQueryTestTypes.scala
@@ -66,7 +66,7 @@ object BigQueryTestTypes {
           "myStruct",
           StandardSQLTypeName.STRUCT,
           FieldList.of(
-            basicOption: _*
+            basicTypes: _*
           )
         )
         .setMode(Mode.NULLABLE)

--- a/bigquery/src/test/scala/org/datatools/bigdatatypes/bigquery/BigQueryTypeConversionSpec.scala
+++ b/bigquery/src/test/scala/org/datatools/bigdatatypes/bigquery/BigQueryTypeConversionSpec.scala
@@ -1,0 +1,82 @@
+package org.datatools.bigdatatypes.bigquery
+
+import com.google.cloud.bigquery.Schema
+import org.datatools.bigdatatypes.BigQueryTestTypes._
+import org.datatools.bigdatatypes.TestTypes.{BasicList, BasicOptionTypes, BasicOptionalStruct, BasicStruct, BasicTypes, ExtendedTypes, ListOfStruct}
+import org.datatools.bigdatatypes.UnitSpec
+import org.datatools.bigdatatypes.basictypes.SqlType
+import org.datatools.bigdatatypes.basictypes.SqlType._
+import org.datatools.bigdatatypes.bigquery.BigQueryTypeConversion.StructFieldSyntax
+import org.datatools.bigdatatypes.bigquery.JavaConverters.toJava
+import org.datatools.bigdatatypes.conversions.SqlTypeConversion
+import org.datatools.bigdatatypes.formats.{DefaultFormats, Formats}
+import org.datatools.bigdatatypes.formats.Formats.implicitDefaultFormats
+
+import scala.annotation.tailrec
+
+/**
+  * This class tests all the conversions between BigQuery objects ([[Schema]] or [[Field]]) into SqlType objects
+  */
+class BigQueryTypeConversionSpec extends UnitSpec {
+
+
+  /**
+    * As BigQuery has less types (e.g: Integer is always Int64, there is no difference between Double and Float)
+    * This is just a "hack" to reduce the types on the Test Types. Without this, we should rewrite all the test examples only for BigQuery
+    * Using this, we can use the Test examples
+    * @param field SqlType that will be converted with Ints to Longs and Doubles to Floats
+    * @return
+    */
+  def reduceBQTypes(field: SqlType): SqlType = {
+    /** small method to loop over structs */
+    def loop(records: List[(String, SqlType)]):  List[(String, SqlType)] = {
+      records.map(record => {
+        record._1 -> reduceBQTypes(record._2)
+      })
+    }
+
+    field match {
+      case SqlInt(mode) => SqlLong(mode)
+      case SqlDouble(mode) => SqlFloat(mode)
+      case SqlStruct(records, mode) => SqlStruct(loop(records), mode)
+      case _ => field
+    }
+  }
+
+  "Basic BQ Schema" should "be converted into SqlType" in {
+    val bqSchema: Schema = Schema.of(toJava(basicFields.toList))
+    val sqlType: SqlType = bqSchema.getType
+    sqlType shouldBe reduceBQTypes(SqlTypeConversion[BasicTypes].getType)
+  }
+
+  "Optional fields in BQ Schema" should "be converted into SqlType" in {
+    val bqSchema: Schema = Schema.of(toJava(basicOptionTypes.toList))
+    bqSchema.getType shouldBe reduceBQTypes(SqlTypeConversion[BasicOptionTypes].getType)
+  }
+
+  "Repeated field in BQ Schema" should "be converted into SqlType" in {
+    val bqSchema: Schema = Schema.of(toJava(basicWithList.toList))
+    bqSchema.getType shouldBe reduceBQTypes(SqlTypeConversion[BasicList].getType)
+  }
+
+  "Nested field in BQ Schema" should "be converted into SqlType" in {
+    val bqSchema: Schema = Schema.of(toJava(basicNested.toList))
+    bqSchema.getType shouldBe reduceBQTypes(SqlTypeConversion[BasicStruct].getType)
+  }
+
+  "Optional Nested field in BQ Schema" should "be converted into SqlType" in {
+    val bqSchema: Schema = Schema.of(toJava(basicOptionalNested.toList))
+    bqSchema.getType shouldBe reduceBQTypes(SqlTypeConversion[BasicOptionalStruct].getType)
+  }
+
+  "Nested field with repeated records in BQ Schema" should "be converted into SqlType" in {
+    val bqSchema: Schema = Schema.of(toJava(basicNestedWithList.toList))
+    bqSchema.getType shouldBe reduceBQTypes(SqlTypeConversion[ListOfStruct].getType)
+  }
+
+  "Extended type fields in BQ Schema" should "be converted into SqlType" in {
+    val bqSchema: Schema = Schema.of(toJava(extendedTypes.toList))
+    bqSchema.getType shouldBe reduceBQTypes(SqlTypeConversion[ExtendedTypes].getType)
+  }
+
+}

--- a/bigquery/src/test/scala/org/datatools/bigdatatypes/bigquery/SqlTypeToBigQuerySpec.scala
+++ b/bigquery/src/test/scala/org/datatools/bigdatatypes/bigquery/SqlTypeToBigQuerySpec.scala
@@ -38,10 +38,9 @@ class SqlTypeToBigQuerySpec extends UnitSpec {
     fields shouldBe BigQueryTestTypes.basicNested
   }
 
-  /** shouldBe fails for a reason in this test */
   "case class with optional nested object" should "be converted into BigQueryFields" in {
     val fields: Seq[Field] = SqlTypeToBigQuery[BasicOptionalStruct].bigQueryFields
-    fields should be equals BigQueryTestTypes.basicOptionalNested
+    fields shouldBe BigQueryTestTypes.basicOptionalNested
   }
 
   "Case class with Struct List" should "be converted into Repeated BigQueryFields" in {

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 //used to build Sonatype releases
-lazy val versionNumber = "0.4.0"
+lazy val versionNumber = "0.5.0"
 lazy val projectName = "big-data-types"
 version := versionNumber
 name := projectName

--- a/examples/src/test/scala/org/datatools/bigdatatypes/CrossModuleExamplesSpec.scala
+++ b/examples/src/test/scala/org/datatools/bigdatatypes/CrossModuleExamplesSpec.scala
@@ -1,13 +1,10 @@
 package org.datatools.bigdatatypes
 
-import org.apache.spark.sql.types.StructType
 import org.datatools.bigdatatypes.TestTypes.BasicTypes
-import org.datatools.bigdatatypes.basictypes.SqlType
-import org.datatools.bigdatatypes.bigquery.{BigQueryTable, SqlInstanceToBigQuery, SqlTypeToBigQuery}
-import org.datatools.bigdatatypes.cassandra.{CassandraTables, SqlInstanceToCassandra}
+import org.datatools.bigdatatypes.bigquery.SqlTypeToBigQuery
+import org.datatools.bigdatatypes.cassandra.CassandraTables
 import org.datatools.bigdatatypes.formats.Formats.implicitDefaultFormats
 import org.datatools.bigdatatypes.spark.SparkSchemas
-import org.datatools.bigdatatypes.spark.SparkTypeConversion.{structType, StructTypeSyntax}
 
 class CrossModuleExamplesSpec extends UnitSpec {
 


### PR DESCRIPTION
This PR implements the BigQuery reverse conversion that allows any BigQuery object (Schema, Field or any basic data type) to be converted into SqlType and doing that, any other type of the library is covered.

In concrete types, this is adding the conversion from BigQuery to Spark and Cassandra for now