### PR TITLE
Cassandra Reverse Conversion

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,13 +1,19 @@
+runner.dialect = scala213source3
 version = "3.1.1"
 maxColumn = 120
 docstrings.blankFirstLine = no
 docstrings.style = SpaceAsterisk
+docstrings.wrap = no
 optIn.breakChainOnFirstMethodDot = true
-align = some
-align.openParenCallSite = false
-align.openParenDefnSite = true
-newlines.alwaysBeforeTopLevelStatements = true
+align {
+    openParenCallSite = false
+    openParenDefnSite = true
+}
+newlines {
+    topLevelStatementBlankLines = [{blanks { before = 1 }}]
+    alwaysBeforeElseAfterCurlyIf = true
+}
 newlines.alwaysBeforeElseAfterCurlyIf = true
 spaces.inImportCurlyBraces = false
-binPack.parentConstructors = Oneline
+binPack.parentConstructors = "source"
 rewrite.rules = [RedundantBraces, RedundantParens, SortModifiers, SortImports]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
   - Added conversion from Cassandra to other types
   - Added a parser and parsing errors
   - Docs improved
+  - Examples from other types to Cassandra
+- BigQuery
+  - Added an extension method to extract Schemas from BigQuery Fields (`myInstance.asBigQuery.schema`)
 
 ## Big Data Types v1.0.0
 - Better public API definition

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### Big Data Types v1.1.0
+- Cassandra
+  - Added conversion from Cassandra to other types
+  - Added a parser and parsing errors
+  - Docs improved
+
 ## Big Data Types v1.0.0
 - Better public API definition
 - Extension methods renamed to a better name (This is a breaking change)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Check the [Documentation website](https://data-tools.github.io/big-data-types) t
 |Scala Types |       -          |:white_check_mark:|:white_check_mark:|:white_check_mark:|
 |BigQuery    |                  |        -         |:white_check_mark:|:white_check_mark:|
 |Spark       |                  |:white_check_mark:|        -         |:white_check_mark:|
-|Cassandra   |                  |                  |                  |        -         |
+|Cassandra   |                  |:white_check_mark:|:white_check_mark:|        -         |
 
 
 Versions for Scala ![Scala 2.12](https://img.shields.io/badge/Scala-2.12-red) ,![Scala_2.13](https://img.shields.io/badge/Scala-2.13-red) 

--- a/bigquery/src/main/scala/org/datatools/bigdatatypes/bigquery/SqlInstanceToBigQuery.scala
+++ b/bigquery/src/main/scala/org/datatools/bigdatatypes/bigquery/SqlInstanceToBigQuery.scala
@@ -1,7 +1,8 @@
 package org.datatools.bigdatatypes.bigquery
 
-import com.google.cloud.bigquery.Field
+import com.google.cloud.bigquery.{Field, Schema}
 import org.datatools.bigdatatypes.basictypes.SqlType
+import org.datatools.bigdatatypes.bigquery.JavaConverters.toJava
 import org.datatools.bigdatatypes.conversions.SqlInstanceConversion
 import org.datatools.bigdatatypes.formats.Formats
 
@@ -54,5 +55,11 @@ object SqlInstanceToBigQuery {
     */
   implicit class InstanceSyntax[A: SqlInstanceToBigQuery](value: A) {
     def asBigQuery: List[Field] = SqlInstanceToBigQuery[A].bigQueryFields(value)
+  }
+
+  /** Allows the syntax myInstance.asBigQuery.schema to retrieve a real [[Schema]] for BigQuery
+    */
+  implicit class InstanceSchemaSyntax(value: List[Field]) {
+    def schema: Schema = Schema.of(toJava(value))
   }
 }

--- a/cassandra/src/main/scala/org/datatools/bigdatatypes/cassandra/CassandraTypeConversion.scala
+++ b/cassandra/src/main/scala/org/datatools/bigdatatypes/cassandra/CassandraTypeConversion.scala
@@ -1,0 +1,72 @@
+package org.datatools.bigdatatypes.cassandra
+
+import com.datastax.oss.driver.api.core.`type`.{DataType, DataTypes, ListType}
+import org.datatools.bigdatatypes.basictypes.SqlType
+import org.datatools.bigdatatypes.basictypes.SqlType.*
+import org.datatools.bigdatatypes.conversions.{SqlInstanceConversion, SqlTypeConversion}
+
+import scala.annotation.tailrec
+
+object CassandraTypeConversion {
+
+  implicit val intType: SqlTypeConversion[DataTypes.INT.type] = SqlTypeConversion.instance(SqlInt())
+  implicit val longType: SqlTypeConversion[DataTypes.BIGINT.type] = SqlTypeConversion.instance(SqlLong())
+  implicit val doubleType: SqlTypeConversion[DataTypes.FLOAT.type] = SqlTypeConversion.instance(SqlDouble())
+  implicit val floatType: SqlTypeConversion[DataTypes.DOUBLE.type] = SqlTypeConversion.instance(SqlFloat())
+  implicit val bigDecimalType: SqlTypeConversion[DataTypes.DECIMAL.type] = SqlTypeConversion.instance(SqlDecimal())
+  implicit val booleanType: SqlTypeConversion[DataTypes.BOOLEAN.type] = SqlTypeConversion.instance(SqlBool())
+  implicit val stringType: SqlTypeConversion[DataTypes.TEXT.type] = SqlTypeConversion.instance(SqlString())
+  //Extended
+  implicit val timestampType: SqlTypeConversion[DataTypes.TIMESTAMP.type] = SqlTypeConversion.instance(SqlTimestamp())
+  implicit val dateType: SqlTypeConversion[DataTypes.DATE.type] = SqlTypeConversion.instance(SqlDate())
+
+  /** Single Field */
+  implicit val cassandraTupleType: SqlInstanceConversion[(String, DataType)] =
+    new SqlInstanceConversion[(String, DataType)] {
+      override def getType(value: (String, DataType)): SqlType = SqlStruct(List(createTuple(value._1, value._2)))
+    }
+
+  /** List of fields */
+  implicit val cassandraFields: SqlInstanceConversion[Iterable[(String, DataType)]] =
+    new SqlInstanceConversion[Iterable[(String, DataType)]] {
+      override def getType(value: Iterable[(String, DataType)]): SqlType = createSqlStruct(value)
+    }
+
+  /** Given a Cassandra Type, returns its representation in SqlType
+    */
+  @tailrec
+  private def convertCassandraType(dataType: DataType, repeated: Boolean = false): SqlType = dataType match {
+    case DataTypes.INT       => SqlInt()
+    case DataTypes.BIGINT    => SqlLong()
+    case DataTypes.FLOAT     => SqlFloat()
+    case DataTypes.DOUBLE    => SqlDouble()
+    case DataTypes.DECIMAL   => SqlDecimal()
+    case DataTypes.BOOLEAN   => SqlBool()
+    case DataTypes.TEXT      => SqlString()
+    case DataTypes.TIMESTAMP => SqlTimestamp()
+    case DataTypes.DATE      => SqlDate()
+    case l: ListType => convertCassandraType(l.getElementType, repeated = true)
+  }
+
+  /** Given a Cassandra Tuple, returns the Tuple ready to be used by SqlStruct */
+  private def createTuple(name: String, t: DataType): (String, SqlType) = (name, convertCassandraType(t))
+
+  /** Given a list of Cassandra tuples, returns a SqlStruct with all the fields inside */
+  private def createSqlStruct(t: Iterable[(String, DataType)]): SqlStruct =
+    SqlStruct(t.toList.map(v => createTuple(v._1, v._2)))
+
+
+  /** Extension method. Enables myInstance.asSqlType syntax
+    * @param value is a tuple from Cassandra
+    */
+  implicit class CassandraTupleSyntax(value: (String, DataType)) {
+    def asSqlType: SqlType = SqlInstanceConversion[(String, DataType)].getType(value)
+  }
+  /** Extension method. Enables myInstance.asSqlType syntax when the instance is a Iterable
+    * @param value is a tuple from Cassandra
+    */
+  implicit class CassandraListTupleSyntax(value: Iterable[(String, DataType)]) {
+    def asSqlType: SqlType = SqlInstanceConversion[List[(String, DataType)]].getType(value.toList)
+  }
+
+}

--- a/cassandra/src/main/scala/org/datatools/bigdatatypes/cassandra/CassandraTypeConversion.scala
+++ b/cassandra/src/main/scala/org/datatools/bigdatatypes/cassandra/CassandraTypeConversion.scala
@@ -16,7 +16,7 @@ object CassandraTypeConversion {
   implicit val bigDecimalType: SqlTypeConversion[DataTypes.DECIMAL.type] = SqlTypeConversion.instance(SqlDecimal())
   implicit val booleanType: SqlTypeConversion[DataTypes.BOOLEAN.type] = SqlTypeConversion.instance(SqlBool())
   implicit val stringType: SqlTypeConversion[DataTypes.TEXT.type] = SqlTypeConversion.instance(SqlString())
-  //Extended
+  // Extended
   implicit val timestampType: SqlTypeConversion[DataTypes.TIMESTAMP.type] = SqlTypeConversion.instance(SqlTimestamp())
   implicit val dateType: SqlTypeConversion[DataTypes.DATE.type] = SqlTypeConversion.instance(SqlDate())
 
@@ -45,7 +45,7 @@ object CassandraTypeConversion {
     case DataTypes.TEXT      => SqlString()
     case DataTypes.TIMESTAMP => SqlTimestamp()
     case DataTypes.DATE      => SqlDate()
-    case l: ListType => convertCassandraType(l.getElementType, repeated = true)
+    case l: ListType         => convertCassandraType(l.getElementType, repeated = true)
   }
 
   /** Given a Cassandra Tuple, returns the Tuple ready to be used by SqlStruct */
@@ -55,13 +55,13 @@ object CassandraTypeConversion {
   private def createSqlStruct(t: Iterable[(String, DataType)]): SqlStruct =
     SqlStruct(t.toList.map(v => createTuple(v._1, v._2)))
 
-
   /** Extension method. Enables myInstance.asSqlType syntax
     * @param value is a tuple from Cassandra
     */
   implicit class CassandraTupleSyntax(value: (String, DataType)) {
     def asSqlType: SqlType = SqlInstanceConversion[(String, DataType)].getType(value)
   }
+
   /** Extension method. Enables myInstance.asSqlType syntax when the instance is a Iterable
     * @param value is a tuple from Cassandra
     */

--- a/cassandra/src/main/scala/org/datatools/bigdatatypes/cassandra/parser/CreateTableParser.scala
+++ b/cassandra/src/main/scala/org/datatools/bigdatatypes/cassandra/parser/CreateTableParser.scala
@@ -1,46 +1,10 @@
 package org.datatools.bigdatatypes.cassandra.parser
 
-import cats.parse.Rfc5234.sp
+import com.datastax.oss.driver.api.core.`type`.{DataType, DataTypes}
+import com.datastax.oss.driver.api.querybuilder.schema.CreateTable
+import org.datatools.bigdatatypes.cassandra.parser.ParsingError.{ErrorParsingField, ParsingErrors, compactErrors}
 
-object CreateTableParser extends App {
-
-  import cats.data.NonEmptyList
-  import cats.parse.Rfc5234.alpha
-  import cats.parse.Parser
-
-  val p: Parser[String] = alpha.rep.map((l: NonEmptyList[Char]) => l.toList.mkString)
-
-  val p2: Parser[String] = alpha.rep.string
-  val p3: Parser[String] = alpha.repAs[String]
-
-  val parenthesis1: Parser[Unit] = Parser.char('(')
-  val parenthesis2: Parser[Unit] = Parser.char(')')
-  val comma: Parser[Unit] = Parser.char(',')
-
-  val words = (alpha.rep ~ sp.rep0).rep
-  val wordWithComma = (words ~ comma.rep0).rep
-
-  val pk = Parser.string("PRIMARY KEY").rep0
-
-  val test = words ~ parenthesis1 *> pk ~ wordWithComma.string <* pk *> wordWithComma.string <* parenthesis2
-  val fieldsString: Parser[String] = words ~ parenthesis1 *> wordWithComma.string <* parenthesis2
-
-  val fieldsString2 = words ~ parenthesis1 *> pk ~ wordWithComma.string <* pk *> wordWithComma.string <* parenthesis2
-
-  val text =
-    "CREATE TABLE testtable (myint int,mylong bigint PRIMARY KEY,myfloat float,mydouble double,mydecimal decimal,myboolean boolean,mystring text)"
-
-  val a: Either[Parser.Error, Array[String]] = fieldsString.parse(text).map(s => s._2.split(","))
-
-  a match {
-    case Left(value)  => ???
-    case Right(value) => value.foreach(println)
-  }
-  println(fieldsString.parse(text))
-
-}
-
-object Test extends App {
+private[cassandra] object CreateTableParser extends App {
 
   val text =
     "CREATE TABLE testtable (myint int,mylong bigint PRIMARY KEY,myfloat float,mydouble double,mydecimal decimal,myboolean boolean,mystring text)"
@@ -48,16 +12,64 @@ object Test extends App {
   val regex = """\((.*)\)""".r
   val pk = " PRIMARY KEY"
 
-  case class ValueType(value: String, t: String)
+  case class NameType(name: String, t: String)
 
-  val a: Option[Array[ValueType]] = regex
-    .findFirstIn(text)
-    .map(s => s.substring(1).substring(0, s.length - 1).replace(pk, ""))
-    .map(s => s.split(','))
-    .map(l => l.map{s =>
-      val both = s.split(' ')
-      ValueType(both.head, both.tail.head)
-    })
+
+  def parse(table: CreateTable): Either[ParsingError, List[NameType]] = {
+    regex
+      .findFirstIn(table.toString)
+      .map(s => s.substring(1).substring(0, s.length - 1).replace(pk, ""))
+      .map(s => s.split(','))
+      .map(l => l.map { s =>
+        val both = s.split(' ')
+        NameType(both.head, both.tail.head)
+      }.toList) match {
+      case Some(value) => Right(value)
+      case None => Left(ParsingError.ErrorParsingTable("Error parsing CreateTable"))
+    }
+  }
+
+  /**
+    * Given a list of parsed fields, return ParsingErrors or the fields parsed and typed for Cassandra
+    * @param fields is a list of Fields parsed
+    * @return Either with [[ParsingErrors]] or a list of fields with their types
+    */
+  def toCassandraTypes(fields: List[NameType]): Either[ParsingError, Seq[(String, DataType)]] = {
+    val typed: Seq[Either[ParsingError, (String, DataType)]] = fields.map(field => parsedToCassandra(field))
+
+    val err = typed.filter(_.isLeft).map {
+      case Left(value) => value
+    }
+
+    if (err.nonEmpty) {
+      Left(compactErrors(err))
+    }
+    else {
+      val values = typed.map {
+        case Right(value) => value
+      }
+      Right(values)
+    }
+  }
+
+  /**
+    * Given a field parsed and it's type, return a valid Cassandra field name and type, or a Parsing error
+    * @param field a field with name and type
+    * @return Either a parsed type or a [[ParsingError]]
+    */
+  def parsedToCassandra(field: NameType): Either[ParsingError, (String, DataType)] = {
+    field.t.toLowerCase match {
+      case "int" => Right((field.name, DataTypes.INT))
+      case "bigint" => Right((field.name, DataTypes.BIGINT))
+      case "float" => Right((field.name, DataTypes.FLOAT))
+      case "double" => Right((field.name, DataTypes.DOUBLE))
+      case "decimal" => Right((field.name, DataTypes.DECIMAL))
+      case "boolean" => Right((field.name, DataTypes.BOOLEAN))
+      case "text" => Right((field.name, DataTypes.TEXT))
+      case _ => Left(ErrorParsingField(field.name, s"Type ${field.t} not implemented"))
+    }
+  }
+
 
 
 }

--- a/cassandra/src/main/scala/org/datatools/bigdatatypes/cassandra/parser/CreateTableParser.scala
+++ b/cassandra/src/main/scala/org/datatools/bigdatatypes/cassandra/parser/CreateTableParser.scala
@@ -2,7 +2,7 @@ package org.datatools.bigdatatypes.cassandra.parser
 
 import com.datastax.oss.driver.api.core.`type`.{DataType, DataTypes}
 import com.datastax.oss.driver.api.querybuilder.schema.CreateTable
-import org.datatools.bigdatatypes.cassandra.parser.ParsingError.{compactErrors, ErrorParsingField, ParsingErrors}
+import org.datatools.bigdatatypes.cassandra.parser.ParsingError.{ErrorParsingField, ParsingErrors, compactErrors}
 
 private[cassandra] object CreateTableParser extends App {
 
@@ -14,8 +14,7 @@ private[cassandra] object CreateTableParser extends App {
 
   case class NameType(name: String, t: String)
 
-  /**
-    * Try to parse a [[CreateTable]] object. It will throw an exception if the parsing fails
+  /** Try to parse a [[CreateTable]] object. It will throw an exception if the parsing fails
     * @param table [[CreateTable]]
     * @return A list of tuples with field name and type for Cassandra.
     */
@@ -25,7 +24,7 @@ private[cassandra] object CreateTableParser extends App {
       fields <- toCassandraTypes(components)
     } yield fields
     fields match {
-      case Left(value) => throw new UnsupportedOperationException(value.msg)
+      case Left(value)  => throw new UnsupportedOperationException(value.msg)
       case Right(value) => value
     }
   }

--- a/cassandra/src/main/scala/org/datatools/bigdatatypes/cassandra/parser/CreateTableParser.scala
+++ b/cassandra/src/main/scala/org/datatools/bigdatatypes/cassandra/parser/CreateTableParser.scala
@@ -2,7 +2,7 @@ package org.datatools.bigdatatypes.cassandra.parser
 
 import com.datastax.oss.driver.api.core.`type`.{DataType, DataTypes}
 import com.datastax.oss.driver.api.querybuilder.schema.CreateTable
-import org.datatools.bigdatatypes.cassandra.parser.ParsingError.{ErrorParsingField, ParsingErrors, compactErrors}
+import org.datatools.bigdatatypes.cassandra.parser.ParsingError.{compactErrors, ErrorParsingField, ParsingErrors}
 
 private[cassandra] object CreateTableParser extends App {
 
@@ -14,62 +14,59 @@ private[cassandra] object CreateTableParser extends App {
 
   case class NameType(name: String, t: String)
 
-
-  def parse(table: CreateTable): Either[ParsingError, List[NameType]] = {
+  /** Given a [[CreateTable]], uses it's representation of String to extract their fields and types
+    * @param table a [[CreateTable]] instance
+    * @return Either a [[ParsingError]] or a list of [[NameType]] with names and types in String
+    */
+  def extractComponents(table: CreateTable): Either[ParsingError, List[NameType]] =
     regex
       .findFirstIn(table.toString)
       .map(s => s.substring(1).substring(0, s.length - 1).replace(pk, ""))
       .map(s => s.split(','))
-      .map(l => l.map { s =>
-        val both = s.split(' ')
-        NameType(both.head, both.tail.head)
-      }.toList) match {
+      .map(l =>
+        l.map { s =>
+          val both = s.split(' ')
+          NameType(both.head, both.tail.head)
+        }.toList
+      ) match {
       case Some(value) => Right(value)
-      case None => Left(ParsingError.ErrorParsingTable("Error parsing CreateTable"))
+      case None        => Left(ParsingError.ErrorParsingTable("Error parsing CreateTable"))
     }
-  }
 
-  /**
-    * Given a list of parsed fields, return ParsingErrors or the fields parsed and typed for Cassandra
+  /** Given a list of parsed fields, return ParsingErrors or the fields parsed and typed for Cassandra
     * @param fields is a list of Fields parsed
     * @return Either with [[ParsingErrors]] or a list of fields with their types
     */
   def toCassandraTypes(fields: List[NameType]): Either[ParsingError, Seq[(String, DataType)]] = {
     val typed: Seq[Either[ParsingError, (String, DataType)]] = fields.map(field => parsedToCassandra(field))
 
-    val err = typed.filter(_.isLeft).map {
-      case Left(value) => value
-    }
+    val err = typed.filter(_.isLeft).map { case Left(value) => value }
 
     if (err.nonEmpty) {
       Left(compactErrors(err))
     }
     else {
-      val values = typed.map {
-        case Right(value) => value
+      val values = typed.map { case Right(value) =>
+        value
       }
       Right(values)
     }
   }
 
-  /**
-    * Given a field parsed and it's type, return a valid Cassandra field name and type, or a Parsing error
+  /** Given a field parsed and it's type, return a valid Cassandra field name and type, or a Parsing error
     * @param field a field with name and type
     * @return Either a parsed type or a [[ParsingError]]
     */
-  def parsedToCassandra(field: NameType): Either[ParsingError, (String, DataType)] = {
+  def parsedToCassandra(field: NameType): Either[ParsingError, (String, DataType)] =
     field.t.toLowerCase match {
-      case "int" => Right((field.name, DataTypes.INT))
-      case "bigint" => Right((field.name, DataTypes.BIGINT))
-      case "float" => Right((field.name, DataTypes.FLOAT))
-      case "double" => Right((field.name, DataTypes.DOUBLE))
+      case "int"     => Right((field.name, DataTypes.INT))
+      case "bigint"  => Right((field.name, DataTypes.BIGINT))
+      case "float"   => Right((field.name, DataTypes.FLOAT))
+      case "double"  => Right((field.name, DataTypes.DOUBLE))
       case "decimal" => Right((field.name, DataTypes.DECIMAL))
       case "boolean" => Right((field.name, DataTypes.BOOLEAN))
-      case "text" => Right((field.name, DataTypes.TEXT))
-      case _ => Left(ErrorParsingField(field.name, s"Type ${field.t} not implemented"))
+      case "text"    => Right((field.name, DataTypes.TEXT))
+      case _         => Left(ErrorParsingField(field.name, s"Error parsing field: Type ${field.t} not implemented"))
     }
-  }
-
-
 
 }

--- a/cassandra/src/main/scala/org/datatools/bigdatatypes/cassandra/parser/CreateTableParser.scala
+++ b/cassandra/src/main/scala/org/datatools/bigdatatypes/cassandra/parser/CreateTableParser.scala
@@ -1,0 +1,63 @@
+package org.datatools.bigdatatypes.cassandra.parser
+
+import cats.parse.Rfc5234.sp
+
+object CreateTableParser extends App {
+
+  import cats.data.NonEmptyList
+  import cats.parse.Rfc5234.alpha
+  import cats.parse.Parser
+
+  val p: Parser[String] = alpha.rep.map((l: NonEmptyList[Char]) => l.toList.mkString)
+
+  val p2: Parser[String] = alpha.rep.string
+  val p3: Parser[String] = alpha.repAs[String]
+
+  val parenthesis1: Parser[Unit] = Parser.char('(')
+  val parenthesis2: Parser[Unit] = Parser.char(')')
+  val comma: Parser[Unit] = Parser.char(',')
+
+  val words = (alpha.rep ~ sp.rep0).rep
+  val wordWithComma = (words ~ comma.rep0).rep
+
+  val pk = Parser.string("PRIMARY KEY").rep0
+
+  val test = words ~ parenthesis1 *> pk ~ wordWithComma.string <* pk *> wordWithComma.string <* parenthesis2
+  val fieldsString: Parser[String] = words ~ parenthesis1 *> wordWithComma.string <* parenthesis2
+
+  val fieldsString2 = words ~ parenthesis1 *> pk ~ wordWithComma.string <* pk *> wordWithComma.string <* parenthesis2
+
+  val text =
+    "CREATE TABLE testtable (myint int,mylong bigint PRIMARY KEY,myfloat float,mydouble double,mydecimal decimal,myboolean boolean,mystring text)"
+
+  val a: Either[Parser.Error, Array[String]] = fieldsString.parse(text).map(s => s._2.split(","))
+
+  a match {
+    case Left(value)  => ???
+    case Right(value) => value.foreach(println)
+  }
+  println(fieldsString.parse(text))
+
+}
+
+object Test extends App {
+
+  val text =
+    "CREATE TABLE testtable (myint int,mylong bigint PRIMARY KEY,myfloat float,mydouble double,mydecimal decimal,myboolean boolean,mystring text)"
+
+  val regex = """\((.*)\)""".r
+  val pk = " PRIMARY KEY"
+
+  case class ValueType(value: String, t: String)
+
+  val a: Option[Array[ValueType]] = regex
+    .findFirstIn(text)
+    .map(s => s.substring(1).substring(0, s.length - 1).replace(pk, ""))
+    .map(s => s.split(','))
+    .map(l => l.map{s =>
+      val both = s.split(' ')
+      ValueType(both.head, both.tail.head)
+    })
+
+
+}

--- a/cassandra/src/main/scala/org/datatools/bigdatatypes/cassandra/parser/ParsingError.scala
+++ b/cassandra/src/main/scala/org/datatools/bigdatatypes/cassandra/parser/ParsingError.scala
@@ -3,12 +3,18 @@ package org.datatools.bigdatatypes.cassandra.parser
 //TODO: This could be moved to a new Parsing module when more modules need a parser
 //make in it private for now to avoid breaking changes in the future
 
-sealed private[parser] trait ParsingError
+sealed private[parser] trait ParsingError {
+  def msg: String
+}
 
 private[parser] object ParsingError {
   case class ErrorParsingTable(msg: String) extends ParsingError
-  case class ErrorParsingField(fieldName: String, msg: String) extends ParsingError
-  case class ParsingErrors(errors: List[ParsingError]) extends ParsingError
+  case class ErrorParsingField(fieldName: String, reason: String) extends ParsingError {
+    override def msg: String = s"Error parsing field $fieldName, reason: $reason"
+  }
+  case class ParsingErrors(errors: List[ParsingError]) extends ParsingError {
+    override def msg: String = "Found Errors:" + errors.reduceLeft(_.msg + " \r\n " +  _.msg )
+  }
 
   /** Given a list of errors, transform them into a [[ParsingErrors]]
     * This could be useful when we want to accumulate all parsing errors

--- a/cassandra/src/main/scala/org/datatools/bigdatatypes/cassandra/parser/ParsingError.scala
+++ b/cassandra/src/main/scala/org/datatools/bigdatatypes/cassandra/parser/ParsingError.scala
@@ -3,35 +3,33 @@ package org.datatools.bigdatatypes.cassandra.parser
 //TODO: This could be moved to a new Parsing module when more modules need a parser
 //make in it private for now to avoid breaking changes in the future
 
-private[parser] sealed trait ParsingError
+sealed private[parser] trait ParsingError
 
 private[parser] object ParsingError {
   case class ErrorParsingTable(msg: String) extends ParsingError
   case class ErrorParsingField(fieldName: String, msg: String) extends ParsingError
   case class ParsingErrors(errors: List[ParsingError]) extends ParsingError
 
-  /**
-    * Given a list of errors, transform them into a [[ParsingErrors]]
+  /** Given a list of errors, transform them into a [[ParsingErrors]]
     * This could be useful when we want to accumulate all parsing errors
     * @param errors a list of [ParsingError]
     * @return [[ParsingError]] with all errors inside
     */
   def compactErrors(errors: Seq[ParsingError]): ParsingErrors = {
-    val acc: ParsingErrors  = ParsingErrors(List.empty[ParsingError])
+    val acc: ParsingErrors = ParsingErrors(List.empty[ParsingError])
     errors.foldLeft(acc)((e1, e2) => ParsingErrors(e1.errors :+ e2))
   }
 
   implicit class ExtensionForError(error: ParsingError) {
-    /**
-      * Add an error to a [[ParsingError]]. It converts the error into a [[ParsingErrors]]
+
+    /** Add an error to a [[ParsingError]]. It converts the error into a [[ParsingErrors]]
       * @param newError the error to be added
       * @return [[ParsingErrors]] with current errors + the new one
       */
-    def addError(newError: ParsingError): ParsingErrors = {
+    def addError(newError: ParsingError): ParsingErrors =
       error match {
         case ParsingErrors(errors) => ParsingErrors(errors :+ newError)
-        case _ => ParsingErrors(List(newError))
+        case _                     => ParsingErrors(List(newError))
       }
-    }
   }
 }

--- a/cassandra/src/main/scala/org/datatools/bigdatatypes/cassandra/parser/ParsingError.scala
+++ b/cassandra/src/main/scala/org/datatools/bigdatatypes/cassandra/parser/ParsingError.scala
@@ -9,11 +9,13 @@ sealed private[parser] trait ParsingError {
 
 private[parser] object ParsingError {
   case class ErrorParsingTable(msg: String) extends ParsingError
+
   case class ErrorParsingField(fieldName: String, reason: String) extends ParsingError {
     override def msg: String = s"Error parsing field $fieldName, reason: $reason"
   }
+
   case class ParsingErrors(errors: List[ParsingError]) extends ParsingError {
-    override def msg: String = "Found Errors:" + errors.map(_.msg).reduceLeft(_ + " \r\n " +  _ )
+    override def msg: String = "Found Errors:" + errors.map(_.msg).reduceLeft(_ + " \r\n " + _)
   }
 
   /** Given a list of errors, transform them into a [[ParsingErrors]]

--- a/cassandra/src/main/scala/org/datatools/bigdatatypes/cassandra/parser/ParsingError.scala
+++ b/cassandra/src/main/scala/org/datatools/bigdatatypes/cassandra/parser/ParsingError.scala
@@ -13,7 +13,7 @@ private[parser] object ParsingError {
     override def msg: String = s"Error parsing field $fieldName, reason: $reason"
   }
   case class ParsingErrors(errors: List[ParsingError]) extends ParsingError {
-    override def msg: String = "Found Errors:" + errors.reduceLeft(_.msg + " \r\n " +  _.msg )
+    override def msg: String = "Found Errors:" + errors.map(_.msg).reduceLeft(_ + " \r\n " +  _ )
   }
 
   /** Given a list of errors, transform them into a [[ParsingErrors]]

--- a/cassandra/src/main/scala/org/datatools/bigdatatypes/cassandra/parser/ParsingError.scala
+++ b/cassandra/src/main/scala/org/datatools/bigdatatypes/cassandra/parser/ParsingError.scala
@@ -1,0 +1,37 @@
+package org.datatools.bigdatatypes.cassandra.parser
+
+//TODO: This could be moved to a new Parsing module when more modules need a parser
+//make in it private for now to avoid breaking changes in the future
+
+private[parser] sealed trait ParsingError
+
+private[parser] object ParsingError {
+  case class ErrorParsingTable(msg: String) extends ParsingError
+  case class ErrorParsingField(fieldName: String, msg: String) extends ParsingError
+  case class ParsingErrors(errors: List[ParsingError]) extends ParsingError
+
+  /**
+    * Given a list of errors, transform them into a [[ParsingErrors]]
+    * This could be useful when we want to accumulate all parsing errors
+    * @param errors a list of [ParsingError]
+    * @return [[ParsingError]] with all errors inside
+    */
+  def compactErrors(errors: Seq[ParsingError]): ParsingErrors = {
+    val acc: ParsingErrors  = ParsingErrors(List.empty[ParsingError])
+    errors.foldLeft(acc)((e1, e2) => ParsingErrors(e1.errors :+ e2))
+  }
+
+  implicit class ExtensionForError(error: ParsingError) {
+    /**
+      * Add an error to a [[ParsingError]]. It converts the error into a [[ParsingErrors]]
+      * @param newError the error to be added
+      * @return [[ParsingErrors]] with current errors + the new one
+      */
+    def addError(newError: ParsingError): ParsingErrors = {
+      error match {
+        case ParsingErrors(errors) => ParsingErrors(errors :+ newError)
+        case _ => ParsingErrors(List(newError))
+      }
+    }
+  }
+}

--- a/cassandra/src/test/scala/org/datatools/bigdatatypes/cassandra/CassandraTypeConversionSpec.scala
+++ b/cassandra/src/test/scala/org/datatools/bigdatatypes/cassandra/CassandraTypeConversionSpec.scala
@@ -1,0 +1,41 @@
+package org.datatools.bigdatatypes.cassandra
+
+import com.datastax.oss.driver.api.core.`type`.{DataType, DataTypes}
+import org.datatools.bigdatatypes.TestTypes.*
+import org.datatools.bigdatatypes.basictypes.*
+import org.datatools.bigdatatypes.basictypes.SqlType.*
+import org.datatools.bigdatatypes.cassandra.CassandraTypeConversion.*
+import org.datatools.bigdatatypes.conversions.{SqlInstanceConversion, SqlTypeConversion}
+import org.datatools.bigdatatypes.{CassandraTestTypes, UnitSpec}
+
+/** Reverse conversion, from Cassandra types to [[SqlType]]s
+  */
+class CassandraTypeConversionSpec extends UnitSpec {
+
+  behavior of "Common Test Types for Spark"
+
+  "Simple Cassandra DataType" should "be converted into SqlType" in {
+    SqlTypeConversion[DataTypes.INT.type].getType shouldBe SqlInt()
+  }
+
+  "Cassandra Tuple" should "be converted into SqlType" in {
+    val t = ("myInt", DataTypes.INT)
+    t.asSqlType shouldBe SqlInt()
+    SqlInstanceConversion[(String, DataType)].getType(t) shouldBe SqlInt()
+  }
+
+  behavior of "Common Test Types for Spark"
+
+  "basic Cassandra schema" should "be converted into SqlTypes" in {
+    CassandraTestTypes.basicFields.asSqlType shouldBe SqlTypeConversion[BasicTypes].getType
+  }
+
+  "Cassandra schema with extended types" should "be converted into Struct with extended types" in {
+    CassandraTestTypes.extendedTypes.asSqlType shouldBe SqlTypeConversion[ExtendedTypes].getType
+  }
+
+  "Cassandra schema with Repeated types" should "be converted into Struct with repeated types" in {
+    CassandraTestTypes.basicWithList.asSqlType
+  }
+
+}

--- a/cassandra/src/test/scala/org/datatools/bigdatatypes/cassandra/CassandraTypeConversionSpec.scala
+++ b/cassandra/src/test/scala/org/datatools/bigdatatypes/cassandra/CassandraTypeConversionSpec.scala
@@ -1,11 +1,11 @@
 package org.datatools.bigdatatypes.cassandra
 
-import com.datastax.oss.driver.api.core.`type`.{DataType, DataTypes}
+import com.datastax.oss.driver.api.core.`type`.DataTypes
 import org.datatools.bigdatatypes.TestTypes.*
 import org.datatools.bigdatatypes.basictypes.*
 import org.datatools.bigdatatypes.basictypes.SqlType.*
 import org.datatools.bigdatatypes.cassandra.CassandraTypeConversion.*
-import org.datatools.bigdatatypes.conversions.{SqlInstanceConversion, SqlTypeConversion}
+import org.datatools.bigdatatypes.conversions.SqlTypeConversion
 import org.datatools.bigdatatypes.{CassandraTestTypes, UnitSpec}
 
 /** Reverse conversion, from Cassandra types to [[SqlType]]s
@@ -20,8 +20,7 @@ class CassandraTypeConversionSpec extends UnitSpec {
 
   "Cassandra Tuple" should "be converted into SqlType" in {
     val t = ("myInt", DataTypes.INT)
-    t.asSqlType shouldBe SqlInt()
-    SqlInstanceConversion[(String, DataType)].getType(t) shouldBe SqlInt()
+    t.asSqlType shouldBe SqlStruct(List(("myInt", SqlInt())))
   }
 
   behavior of "Common Test Types for Spark"

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -38,6 +38,6 @@ without having code that relates BigQuery and Spark directly.
 |Scala Types |       -          |:white_check_mark:|:white_check_mark:|:white_check_mark:|
 |BigQuery    |                  |        -         |:white_check_mark:|:white_check_mark:|
 |Spark       |                  |:white_check_mark:|        -         |:white_check_mark:|
-|Cassandra   |                  |                  |                  |        -         |
+|Cassandra   |                  |:white_check_mark:|:white_check_mark:|        -         |
 
 

--- a/examples/src/test/scala/org/datatools/bigdatatypes/CassandraToOthers.scala
+++ b/examples/src/test/scala/org/datatools/bigdatatypes/CassandraToOthers.scala
@@ -5,7 +5,6 @@ import com.datastax.oss.driver.api.querybuilder.SchemaBuilder.createTable
 import com.datastax.oss.driver.api.querybuilder.schema.CreateTable
 import com.google.cloud.bigquery.Field.Mode
 import com.google.cloud.bigquery.{Field, Schema, StandardSQLTypeName}
-import org.datatools.bigdatatypes.BigQueryTestTypes.basicFields
 import org.datatools.bigdatatypes.bigquery.JavaConverters.toJava
 import org.datatools.bigdatatypes.bigquery.SqlInstanceToBigQuery
 import org.datatools.bigdatatypes.bigquery.SqlInstanceToBigQuery.{InstanceSchemaSyntax, InstanceSyntax}

--- a/examples/src/test/scala/org/datatools/bigdatatypes/CassandraToOthers.scala
+++ b/examples/src/test/scala/org/datatools/bigdatatypes/CassandraToOthers.scala
@@ -3,6 +3,14 @@ package org.datatools.bigdatatypes
 import com.datastax.oss.driver.api.core.`type`.DataTypes
 import com.datastax.oss.driver.api.querybuilder.SchemaBuilder.createTable
 import com.datastax.oss.driver.api.querybuilder.schema.CreateTable
+import com.google.cloud.bigquery.Field.Mode
+import com.google.cloud.bigquery.{Field, Schema, StandardSQLTypeName}
+import org.datatools.bigdatatypes.BigQueryTestTypes.basicFields
+import org.datatools.bigdatatypes.bigquery.JavaConverters.toJava
+import org.datatools.bigdatatypes.bigquery.SqlInstanceToBigQuery
+import org.datatools.bigdatatypes.bigquery.SqlInstanceToBigQuery.{InstanceSchemaSyntax, InstanceSyntax}
+import org.datatools.bigdatatypes.cassandra.CassandraTypeConversion.cassandraCreateTable
+import org.datatools.bigdatatypes.formats.Formats.implicitDefaultFormats
 
 class CassandraToOthers extends UnitSpec {
 
@@ -14,6 +22,14 @@ class CassandraToOthers extends UnitSpec {
       .withColumn("foo", DataTypes.TEXT)
       .withColumn("bar", DataTypes.INT)
 
-  // TODO missing implementation of CassandraTypeConversion that will allow any CreateTable to be transformed
-
+  "Cassandra table" should "be converted into BigQuery Schema" in {
+    val fields = List(
+      Field.newBuilder("id", StandardSQLTypeName.STRING).setMode(Mode.REQUIRED).build(),
+      Field.newBuilder("foo", StandardSQLTypeName.STRING).setMode(Mode.REQUIRED).build(),
+      Field.newBuilder("bar", StandardSQLTypeName.INT64).setMode(Mode.REQUIRED).build()
+    )
+    val bqSchema = Schema.of(toJava(fields))
+    SqlInstanceToBigQuery[CreateTable]
+    cassandraTable.asBigQuery.schema shouldBe bqSchema
+  }
 }

--- a/examples/src/test/scala_2/bigdatatypes/CassandraToOthers.scala
+++ b/examples/src/test/scala_2/bigdatatypes/CassandraToOthers.scala
@@ -21,13 +21,14 @@ class CassandraToOthers extends UnitSpec {
       .withColumn("bar", DataTypes.INT)
 
   "Cassandra table" should "be converted into Spark Schema" in {
-    //val sparkSchema: StructType = myDataFrame.schema
+    // val sparkSchema: StructType = myDataFrame.schema
     val sparkSchema: StructType = StructType(
       List(
         StructField("id", StringType, nullable = false),
         StructField("foo", StringType, nullable = false),
         StructField("bar", IntegerType, nullable = false)
-      ))
+      )
+    )
     SqlInstanceToBigQuery[CreateTable]
     cassandraTable.asSparkSchema shouldBe sparkSchema
   }

--- a/examples/src/test/scala_2/bigdatatypes/CassandraToOthers.scala
+++ b/examples/src/test/scala_2/bigdatatypes/CassandraToOthers.scala
@@ -1,0 +1,34 @@
+package bigdatatypes
+
+import com.datastax.oss.driver.api.core.`type`.DataTypes
+import com.datastax.oss.driver.api.querybuilder.SchemaBuilder.createTable
+import com.datastax.oss.driver.api.querybuilder.schema.CreateTable
+import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
+import org.datatools.bigdatatypes.UnitSpec
+import org.datatools.bigdatatypes.bigquery.SqlInstanceToBigQuery
+import org.datatools.bigdatatypes.cassandra.CassandraTypeConversion.cassandraCreateTable
+import org.datatools.bigdatatypes.formats.Formats.implicitDefaultFormats
+import org.datatools.bigdatatypes.spark.SqlInstanceToSpark.InstanceSyntax
+
+class CassandraToOthers extends UnitSpec {
+
+  behavior of "Cassandra Types to other types"
+
+  val cassandraTable: CreateTable =
+    createTable("TestTable")
+      .withPartitionKey("id", DataTypes.TEXT)
+      .withColumn("foo", DataTypes.TEXT)
+      .withColumn("bar", DataTypes.INT)
+
+  "Cassandra table" should "be converted into Spark Schema" in {
+    //val sparkSchema: StructType = myDataFrame.schema
+    val sparkSchema: StructType = StructType(
+      List(
+        StructField("id", StringType, nullable = false),
+        StructField("foo", StringType, nullable = false),
+        StructField("bar", IntegerType, nullable = false)
+      ))
+    SqlInstanceToBigQuery[CreateTable]
+    cassandraTable.asSparkSchema shouldBe sparkSchema
+  }
+}


### PR DESCRIPTION
This PRs implements the transformation from Cassandra `CreateTable`s to the generic `SqlType`, allowing any Cassandra table definition be converted into any of the other types of the library.

Main Changes:
- Cassandra
  - Added conversion from Cassandra to other types
  - Added a parser and parsing errors
  - Docs improved
  - Examples from other types to Cassandra
- BigQuery
  - Added an extension method to extract Schemas from BigQuery Fields (`myInstance.asBigQuery.schema`)

This closes the issue https://github.com/data-tools/big-data-types/issues/115

