### PR TITLE
Dependencies + Scala 3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### Big Data Types v1.2.1
+Some dependencies (Circe - ScalaTest) have updated Scala to 3.1.X
+- Dependencies updated to newer versions
+- Scala version changed to 3.1.X
+  - This version is no longer compatible with Scala 3.0.X
+
 ### Big Data Types v1.2.0
 - New module for Circe (JSON)
   - Conversion from Circe to other types

--- a/build.sbt
+++ b/build.sbt
@@ -1,12 +1,12 @@
 //used to build Sonatype releases
-lazy val versionNumber = "1.2.0"
+lazy val versionNumber = "1.2.1"
 lazy val projectName = "big-data-types"
 version := versionNumber
 name := projectName
 
 lazy val scala213 = "2.13.7"
 lazy val scala212 = "2.12.15"
-lazy val scala3 = "3.0.2"
+lazy val scala3 = "3.1.0"
 lazy val supportedScalaVersions = List(scala3, scala213, scala212)
 scalaVersion := scala213
 
@@ -69,7 +69,7 @@ lazy val cassandraDependencies = Seq(
   scalatest % Test
 )
 
-val circeVersion = "0.14.1"
+val circeVersion = "0.14.2"
 
 lazy val jsonCirceDependencies = Seq(
   "io.circe" %% "circe-core",
@@ -77,7 +77,7 @@ lazy val jsonCirceDependencies = Seq(
   "io.circe" %% "circe-parser"
 ).map(_ % circeVersion)
 
-lazy val scalatest = "org.scalatest" %% "scalatest" % "3.2.11"
+lazy val scalatest = "org.scalatest" %% "scalatest" % "3.2.13"
 
 //Project settings
 lazy val root = (project in file("."))


### PR DESCRIPTION
ScalaTest 3.1.12 and Circe 0.14.2 are no longer compatible with Scala 3.0.X This PR increases de version of them to the latest and changes the version of the library to Scala 3.1.0

This version is no longer compatible with Scala 3.0.X