### PR TITLE
Upgrade to Scala 3.3.3 LTS

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ name := projectName
 
 lazy val scala213 = "2.13.14"
 lazy val scala212 = "2.12.19"
-lazy val scala3 = "3.1.0"
+lazy val scala3 = "3.3.3"
 lazy val supportedScalaVersions = List(scala3, scala213, scala212)
 scalaVersion := scala213
 


### PR DESCRIPTION
This library tried to keep the lowest version of Scala 3 possible as they should be forward compatible, but after having issues with some dependencies, we are upgrading to the LTS version. 